### PR TITLE
Fix macos tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
         - macos-latest
@@ -29,11 +29,11 @@ jobs:
         - ubuntu-latest
         include:
         - os: macos-latest
-          deps: brew install ninja
+          deps: brew install ninja icu4c
           cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH_SH=/opt/homebrew/opt/icu4c/include
           run-tests: false
         - os: macos-13
-          deps: brew install ninja
+          deps: brew install ninja icu4c
           cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
           run-tests: true
         - os: ubuntu-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,17 +23,12 @@ jobs:
       matrix:
         os:
         - macos-latest
-        - macos-12
         - macos-13
         - ubuntu-latest
         include:
         - os: macos-latest
           deps: brew install ninja icu4c
           cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON
-          run-tests: true
-        - os: macos-12
-          deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
           run-tests: true
         - os: macos-13
           deps: brew install ninja icu4c

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,8 +12,6 @@ concurrency:
 
 env:
   BUILD_TYPE: RelWithDebInfo
-  CC: clang
-  CXX: clang++
 
 jobs:
   build:
@@ -26,15 +24,20 @@ jobs:
         os:
         - macos-latest
         - macos-12
+        - macos-13
         - ubuntu-latest
         include:
         - os: macos-latest
           deps: brew install ninja icu4c
-          cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include
-          run-tests: false
+          cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include
+          run-tests: true
         - os: macos-12
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
+          run-tests: true
+        - os: macos-13
+          deps: brew install ninja icu4c
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build
@@ -59,7 +62,7 @@ jobs:
 
     - name: Configure CMake
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ${{ matrix.cmake-flags }} -G Ninja ${{ github.workspace }}/chakracore-cxx
+      run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ${{ matrix.cmake-flags }} -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
 
     - name: Build
       working-directory: ${{ steps.strings.outputs.build-output-dir }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
           run-tests: true
         - os: macos-13
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ jobs:
           run-tests: false
         - os: macos-12
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  BUILD_TYPE: Debug
+  BUILD_TYPE: RelWithDebInfo
   CC: clang
   CXX: clang++
 
@@ -25,16 +25,16 @@ jobs:
       matrix:
         os:
         - macos-latest
-        - macos-13
+        - macos-12
         - ubuntu-latest
         include:
         - os: macos-latest
           deps: brew install ninja icu4c
           cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include
           run-tests: false
-        - os: macos-13
+        - os: macos-12
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,11 +30,11 @@ jobs:
         include:
         - os: macos-latest
           deps: brew install ninja icu4c
-          cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH_SH=/opt/homebrew/opt/icu4c/include
+          cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include
           run-tests: false
         - os: macos-13
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
         include:
         - os: macos-latest
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include
+          cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON
           run-tests: true
         - os: macos-12
           deps: brew install ninja icu4c

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
           run-tests: true
         - os: macos-13
           deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DSTATIC_LIBRARY=ON
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include -DDISABLE_JIT=ON
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,16 +21,21 @@ jobs:
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
-      fail-fast: false
+      fail-fast: true
       matrix:
         os:
         - macos-latest
+        - macos-13
         - ubuntu-latest
         include:
         - os: macos-latest
           deps: brew install ninja
           cmake-flags: -DDISABLE_JIT=1 -DICU_INCLUDE_PATH_SH=/opt/homebrew/opt/icu4c/include
           run-tests: false
+        - os: macos-13
+          deps: brew install ninja
+          cmake-flags: ''
+          run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build
           cmake-flags: ''

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,7 +34,7 @@ jobs:
           run-tests: false
         - os: macos-13
           deps: brew install ninja
-          cmake-flags: ''
+          cmake-flags: -DICU_INCLUDE_PATH=/usr/local/opt/icu4c/include
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os:
         - macos-latest
+        - macos-13
         - ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Got tests working in macos-latest, macos-12, and macos-13. However, I removed the macos-12 changes since I only want macos-13 (intel) and macos-latest (arm). Needed to disable JIT on macos-latest and macos-13, not sure why it doesn't work on 13 if it works on 12.