### PR TITLE
Fix build errors and warnings

### DIFF
--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -24,8 +24,8 @@ jobs:
         - ubuntu-latest
         include:
         - os: macos-latest
-          deps: brew install ninja icu4c
-          cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c/include -DDISABLE_JIT=ON
+          deps: brew install ninja icu4c@74
+          cmake-flags: -DICU_INCLUDE_PATH=/opt/homebrew/opt/icu4c@74/include -DDISABLE_JIT=ON
           run-tests: true
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build

--- a/chakracore-cxx/bin/ChakraCore/CMakeLists.txt
+++ b/chakracore-cxx/bin/ChakraCore/CMakeLists.txt
@@ -43,7 +43,6 @@ endif()
 
 # common link deps
 set(lib_target "${lib_target}"
-  -Wl,-undefined,error
   ${LINKER_START_GROUP}
   ChakraCoreStatic
   ${ICU_LIBRARIES}

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -64,7 +64,6 @@ endif()
 
 # common link deps
 set(lib_target "${lib_target}"
-  -Wl,-undefined,error
   ${LINKER_START_GROUP}
   ChakraCoreStatic
   ${ICU_LIBRARIES}


### PR DESCRIPTION
- icu4c 75+ requires C++17, restricting to 74 for now
- remove `-undefined,error` as it's deprecated