### PR TITLE
cxx build improvements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,7 @@ fn build_cmake() {
         .generator("Ninja")
         .define("CMAKE_CXX_COMPILER", "clang++")
         .define("CMAKE_C_COMPILER", "clang")
+        .profile("RelWithDebInfo")
         .build_target("ch");
 
     let target = std::env::var("TARGET").unwrap();

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 project (CHAKRACORE)
 
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")

--- a/chakracore-cxx/lib/wabt/CMakeLists.txt
+++ b/chakracore-cxx/lib/wabt/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 project(WABT)
 
 set(COMPILER_IS_CLANG 1)

--- a/chakracore-cxx/pal/CMakeLists.txt
+++ b/chakracore-cxx/pal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 
 project(COREPAL)
 

--- a/chakracore-cxx/pal/src/CMakeLists.txt
+++ b/chakracore-cxx/pal/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 
 project(chakrapal)
 


### PR DESCRIPTION
- downgrade cmake for ubuntu 24.04
- use RelWithDebInfo for CMAKE_BUILD_TYPE. This will cause slower build times but faster test times.
