### PR TITLE
nextest - don't fail fast

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Build
         run: cargo build -vv
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run --no-fail-fast


### PR DESCRIPTION
cargo-nextest by default runs until the first failure. Run with `--no-fail-fast` to run all tests even with failures.