### PR TITLE
Move TTD param parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM --platform=linux/amd64 ubuntu:24.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update  \
     && apt-get -y install \
     build-essential \
+    gcc-14 g++-14 \
     curl \
     git \
     cmake \

--- a/chakra/src/lib.rs
+++ b/chakra/src/lib.rs
@@ -25,10 +25,13 @@ pub fn print_usage() {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ChakraArgs {
     pub version: bool,
     pub help: bool,
+    pub tt_snap_interval: u32,
+    pub tt_snap_history_length: u32,
+    pub ttd_start_event_count: u32,
 }
 
 impl ChakraArgs {
@@ -36,6 +39,8 @@ impl ChakraArgs {
         if args.len() < 2 {
             return None;
         }
+
+        let mut chakra_args = ChakraArgs::default();
 
         for arg in &args {
             if arg == "-v" || arg == "--version" {
@@ -51,8 +56,19 @@ impl ChakraArgs {
                     ..ChakraArgs::default()
                 });
             }
+
+            if arg.starts_with("-TTSnapInterval=") {
+                let raw_value = arg.split('=').next().unwrap_or_default();
+                chakra_args.tt_snap_interval = raw_value.parse::<u32>().unwrap_or(u32::MAX);
+            } else if arg.starts_with("-TTHistoryLength=") {
+                let raw_value = arg.split('=').next().unwrap_or_default();
+                chakra_args.tt_snap_history_length = raw_value.parse::<u32>().unwrap_or(u32::MAX);
+            } else if arg.starts_with("-TTDStartEvent=") {
+                let raw_value = arg.split('=').next().unwrap_or_default();
+                chakra_args.ttd_start_event_count = raw_value.parse::<u32>().unwrap_or(1);
+            }
         }
 
-        Some(ChakraArgs::default())
+        Some(chakra_args)
     }
 }

--- a/chakra/src/lib.rs
+++ b/chakra/src/lib.rs
@@ -4,7 +4,6 @@ use std::env::current_exe;
 mod ffi {
     extern "Rust" {
         fn print_usage();
-        fn get_ttd_directory(record_uri: String) -> String;
     }
 }
 
@@ -44,6 +43,9 @@ pub struct ChakraArgs {
     pub tt_snap_interval: u32,
     pub tt_snap_history_length: u32,
     pub ttd_start_event_count: u32,
+    pub do_tt_record: bool,
+    pub do_tt_replay: bool,
+    pub tt_uri: String,
 }
 
 impl ChakraArgs {
@@ -69,7 +71,15 @@ impl ChakraArgs {
                 });
             }
 
-            if arg.starts_with("-TTSnapInterval=") {
+            if arg.starts_with("-TTRecord=") {
+                chakra_args.do_tt_record = true;
+                let record_uri = arg.split('=').next().unwrap_or_default().to_owned();
+                chakra_args.tt_uri = get_ttd_directory(record_uri);
+            } else if arg.starts_with("-TTReplay=") {
+                chakra_args.do_tt_replay = true;
+                let record_uri = arg.split('=').next().unwrap_or_default().to_owned();
+                chakra_args.tt_uri = get_ttd_directory(record_uri);
+            } else if arg.starts_with("-TTSnapInterval=") {
                 let raw_value = arg.split('=').next().unwrap_or_default();
                 chakra_args.tt_snap_interval = raw_value.parse::<u32>().unwrap_or(u32::MAX);
             } else if arg.starts_with("-TTHistoryLength=") {

--- a/chakra/src/lib.rs
+++ b/chakra/src/lib.rs
@@ -1,7 +1,10 @@
+use std::env::current_exe;
+
 #[cxx::bridge(namespace = "chakra")]
 mod ffi {
     extern "Rust" {
         fn print_usage();
+        fn get_ttd_directory(record_uri: String) -> String;
     }
 }
 
@@ -23,6 +26,15 @@ pub fn print_usage() {
         println!("\t-v|--version\t\tDisplays version info");
         println!("\t-h|--help|-?\t\tDisplays this help message");
     }
+}
+
+fn get_ttd_directory(record_uri: String) -> String {
+    let exe = current_exe().unwrap();
+    let exe_dir = exe.parent().unwrap().to_owned();
+
+    let directory = exe_dir.join("_ttdlog").join(record_uri);
+    std::fs::create_dir_all(&directory).unwrap();
+    directory.to_string_lossy().into_owned()
 }
 
 #[derive(Debug, Clone, Default)]

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -152,7 +152,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-tautological-constant-compare\
     -Wno-enum-compare-switch\
     -Wno-delayed-template-parsing-in-cxx20\
-    -Wno-unknown-warning-option"
+    -Wno-unknown-warning-option\
+    -Wno-nontrivial-memcall"
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -448,12 +448,12 @@ void Helpers::TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg)
 //We assume bounded ascii path length for simplicity
 #define MAX_TTD_ASCII_PATH_EXT_LENGTH 64
 
-void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char16_t* asciiDir2)
+void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char* asciiDir2)
 {
-    if(*uriLength + strlen(asciiDir1) + PAL_wcslen(asciiDir2) + 2 > MAX_URI_LENGTH || strlen(asciiDir1) >= MAX_TTD_ASCII_PATH_EXT_LENGTH || PAL_wcslen(asciiDir2) >= MAX_TTD_ASCII_PATH_EXT_LENGTH)
+    if(*uriLength + strlen(asciiDir1) + strlen(asciiDir2) + 2 > MAX_URI_LENGTH || strlen(asciiDir1) >= MAX_TTD_ASCII_PATH_EXT_LENGTH || strlen(asciiDir2) >= MAX_TTD_ASCII_PATH_EXT_LENGTH)
     {
         PAL_wprintf(u"We assume bounded MAX_URI_LENGTH for simplicity.\n");
-        PAL_wprintf(u"%S, %S, %ls\n", uri, asciiDir1, asciiDir2);
+        PAL_wprintf(u"%S, %S, %S\n", uri, asciiDir1, asciiDir2);
         exit(1);
     }
 
@@ -476,19 +476,7 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
         Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
 
-    char realAsciiDir2[MAX_TTD_ASCII_PATH_EXT_LENGTH];
-    size_t asciiDir2Length = PAL_wcslen(asciiDir2) + 1;
-    for(size_t i = 0; i < asciiDir2Length; ++i)
-    {
-        if(asciiDir2[i] > CHAR_MAX)
-        {
-            PAL_wprintf(u"Test directory names can only include ascii chars.\n");
-            exit(1);
-        }
-        realAsciiDir2[i] = (char)asciiDir2[i];
-    }
-
-    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", realAsciiDir2, TTD_HOST_PATH_SEP);
+    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir2, TTD_HOST_PATH_SEP);
     if(extLength == -1 || MAX_URI_LENGTH < *uriLength + extLength)
     {
         PAL_wprintf(u"Failed directory create 2.\n");
@@ -505,7 +493,7 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
     }
 }
 
-void Helpers::GetTTDDirectory(const char16_t* curi, size_t* uriLength, char* uri, size_t bufferLength)
+void Helpers::GetTTDDirectory(const char* curi, size_t* uriLength, char* uri, size_t bufferLength)
 {
     TTDHostBuildCurrentExeDirectory(uri, uriLength, bufferLength);
 

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -2,10 +2,13 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+#include <filesystem>
+
 #include "stdafx.h"
 #include <iostream>
 #include <limits>
 #include <sys/stat.h>
+#include <__filesystem/filesystem_error.h>
 
 #define MAX_URI_LENGTH 512
 
@@ -449,56 +452,33 @@ void Helpers::TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg)
 //We assume bounded ascii path length for simplicity
 #define MAX_TTD_ASCII_PATH_EXT_LENGTH 64
 
-void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const std::string& asciiDir1, const std::string& asciiDir2)
+std::string Helpers::CreateTTDDirectoryAsNeeded(const std::string& exeDir, const std::string& asciiDir1, const std::string& asciiDir2)
 {
-    if(*uriLength + asciiDir1.length() + asciiDir2.length() + 2 > MAX_URI_LENGTH || asciiDir1.length() >= MAX_TTD_ASCII_PATH_EXT_LENGTH || asciiDir2.length() >= MAX_TTD_ASCII_PATH_EXT_LENGTH)
-    {
-        std::cout << "We assume bounded MAX_URI_LENGTH for simplicity." << std::endl;
-        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
-        exit(1);
-    }
-
-    int success = 0;
-    int extLength = 0;
-
-    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir1.data(), TTD_HOST_PATH_SEP);
-    if(extLength == -1 || MAX_URI_LENGTH < (*uriLength) + extLength)
-    {
-        std::cout << "Failed directory extension 1." << std::endl;
-        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
-        exit(1);
-    }
-    *uriLength += extLength;
-
-    success = TTDHostMKDir(uri, *uriLength);
-    if(success != 0)
+    std::string out1 = exeDir + asciiDir1 + TTD_HOST_PATH_SEP;
+    if(!std::filesystem::create_directory(out1))
     {
         //we may fail because someone else created the directory -- that is ok
         Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
 
-    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir2.data(), TTD_HOST_PATH_SEP);
-    if(extLength == -1 || MAX_URI_LENGTH < *uriLength + extLength)
-    {
-        std::cout << "Failed directory create 2." << std::endl;
-        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
-        exit(1);
-    }
-    *uriLength += extLength;
-
-    success = TTDHostMKDir(uri, *uriLength);
-    if(success != 0)
+    std::string out2 = out1 + asciiDir2 + TTD_HOST_PATH_SEP;
+    if(!std::filesystem::create_directory(out2))
     {
         //we may fail because someone else created the directory -- that is ok
         Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
+    return out2;
 }
 
-void Helpers::GetTTDDirectory(const std::string_view curi, size_t* uriLength, char* uri, size_t bufferLength)
+std::string Helpers::GetTTDDirectory(const std::string_view curi)
 {
-    TTDHostBuildCurrentExeDirectory(uri, uriLength, bufferLength);
+    char ttUri[PATH_MAX];
+    size_t ttUriLength = 0;
+    TTDHostBuildCurrentExeDirectory(ttUri, &ttUriLength, PATH_MAX);
 
-    Helpers::CreateTTDDirectoryAsNeeded(uriLength, uri, "_ttdlog", curi);
+    std::string exeDir(ttUri, ttUriLength);
+
+    return Helpers::CreateTTDDirectoryAsNeeded(exeDir, "_ttdlog", std::string(curi));
 }
 
 JsTTDStreamHandle CALLBACK Helpers::TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write)

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
+#include <iostream>
 #include <limits>
 #include <sys/stat.h>
 
@@ -23,12 +24,12 @@ void TTDHostBuildCurrentExeDirectory(char* path, size_t* pathLength, size_t buff
     }
     if (i == 0)
     {
-        PAL_fwprintf(PAL_get_stderr(), u"Can't get current exe directory");
+        std::cerr << "Can't get current exe directory" << std::endl;
         exit(1);
     }
     if (i + 2 > bufferLength)
     {
-        PAL_fwprintf(PAL_get_stderr(), u"Don't overflow path buffer during copy");
+        std::cerr << "Don't overflow path buffer during copy" << std::endl;
         exit(1);
     }
     memcpy(path, exePath, i + 1);
@@ -448,23 +449,23 @@ void Helpers::TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg)
 //We assume bounded ascii path length for simplicity
 #define MAX_TTD_ASCII_PATH_EXT_LENGTH 64
 
-void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char* asciiDir2)
+void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const std::string& asciiDir1, const std::string& asciiDir2)
 {
-    if(*uriLength + strlen(asciiDir1) + strlen(asciiDir2) + 2 > MAX_URI_LENGTH || strlen(asciiDir1) >= MAX_TTD_ASCII_PATH_EXT_LENGTH || strlen(asciiDir2) >= MAX_TTD_ASCII_PATH_EXT_LENGTH)
+    if(*uriLength + asciiDir1.length() + asciiDir2.length() + 2 > MAX_URI_LENGTH || asciiDir1.length() >= MAX_TTD_ASCII_PATH_EXT_LENGTH || asciiDir2.length() >= MAX_TTD_ASCII_PATH_EXT_LENGTH)
     {
-        PAL_wprintf(u"We assume bounded MAX_URI_LENGTH for simplicity.\n");
-        PAL_wprintf(u"%S, %S, %S\n", uri, asciiDir1, asciiDir2);
+        std::cout << "We assume bounded MAX_URI_LENGTH for simplicity." << std::endl;
+        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
         exit(1);
     }
 
     int success = 0;
     int extLength = 0;
 
-    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir1, TTD_HOST_PATH_SEP);
+    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir1.data(), TTD_HOST_PATH_SEP);
     if(extLength == -1 || MAX_URI_LENGTH < (*uriLength) + extLength)
     {
-        PAL_wprintf(u"Failed directory extension 1.\n");
-        PAL_wprintf(u"%S, %S, %ls\n", uri, asciiDir1, asciiDir2);
+        std::cout << "Failed directory extension 1." << std::endl;
+        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
         exit(1);
     }
     *uriLength += extLength;
@@ -476,11 +477,11 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
         Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
 
-    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir2, TTD_HOST_PATH_SEP);
+    extLength = snprintf(uri + *uriLength, MAX_TTD_ASCII_PATH_EXT_LENGTH, "%s%s", asciiDir2.data(), TTD_HOST_PATH_SEP);
     if(extLength == -1 || MAX_URI_LENGTH < *uriLength + extLength)
     {
-        PAL_wprintf(u"Failed directory create 2.\n");
-        PAL_wprintf(u"%S, %S, %ls\n", uri, asciiDir1, asciiDir2);
+        std::cout << "Failed directory create 2." << std::endl;
+        std::cout << uri << ", " << asciiDir1 << ", " << asciiDir2 << std::endl;
         exit(1);
     }
     *uriLength += extLength;
@@ -493,7 +494,7 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
     }
 }
 
-void Helpers::GetTTDDirectory(const char* curi, size_t* uriLength, char* uri, size_t bufferLength)
+void Helpers::GetTTDDirectory(const std::string_view curi, size_t* uriLength, char* uri, size_t bufferLength)
 {
     TTDHostBuildCurrentExeDirectory(uri, uriLength, bufferLength);
 

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -2,48 +2,12 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#include <filesystem>
-
 #include "stdafx.h"
 #include <iostream>
 #include <limits>
 #include <sys/stat.h>
-#include <__filesystem/filesystem_error.h>
 
 #define MAX_URI_LENGTH 512
-
-#define TTD_MAX_FILE_LENGTH MAX_URI_LENGTH
-#define TTD_HOST_PATH_SEP "/"
-
-void TTDHostBuildCurrentExeDirectory(char* path, size_t* pathLength, size_t bufferLength)
-{
-    char exePath[TTD_MAX_FILE_LENGTH];
-    PlatformAgnostic::SystemInfo::GetBinaryLocation(exePath, TTD_MAX_FILE_LENGTH);
-
-    size_t i = strlen(exePath) - 1;
-    while (exePath[i] != TTD_HOST_PATH_SEP[0] && i != 0)
-    {
-        --i;
-    }
-    if (i == 0)
-    {
-        std::cerr << "Can't get current exe directory" << std::endl;
-        exit(1);
-    }
-    if (i + 2 > bufferLength)
-    {
-        std::cerr << "Don't overflow path buffer during copy" << std::endl;
-        exit(1);
-    }
-    memcpy(path, exePath, i + 1);
-    *pathLength = i + 1;
-    path[*pathLength] = '\0';
-}
-
-int TTDHostMKDir(const char* path, size_t pathLength)
-{
-    return mkdir(path, 0700);
-}
 
 JsTTDStreamHandle TTDHostOpen(size_t pathLength, const char* path, bool isWrite)
 {
@@ -449,38 +413,6 @@ void Helpers::TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg)
     }
 }
 
-//We assume bounded ascii path length for simplicity
-#define MAX_TTD_ASCII_PATH_EXT_LENGTH 64
-
-std::string Helpers::CreateTTDDirectoryAsNeeded(const std::string& exeDir, const std::string& asciiDir1, const std::string& asciiDir2)
-{
-    std::string out1 = exeDir + asciiDir1 + TTD_HOST_PATH_SEP;
-    if(!std::filesystem::create_directory(out1))
-    {
-        //we may fail because someone else created the directory -- that is ok
-        Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
-    }
-
-    std::string out2 = out1 + asciiDir2 + TTD_HOST_PATH_SEP;
-    if(!std::filesystem::create_directory(out2))
-    {
-        //we may fail because someone else created the directory -- that is ok
-        Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
-    }
-    return out2;
-}
-
-std::string Helpers::GetTTDDirectory(const std::string_view curi)
-{
-    char ttUri[PATH_MAX];
-    size_t ttUriLength = 0;
-    TTDHostBuildCurrentExeDirectory(ttUri, &ttUriLength, PATH_MAX);
-
-    std::string exeDir(ttUri, ttUriLength);
-
-    return Helpers::CreateTTDDirectoryAsNeeded(exeDir, "_ttdlog", std::string(curi));
-}
-
 JsTTDStreamHandle CALLBACK Helpers::TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write)
 {
     AssertMsg((read | write) & (!read | !write), "Read/Write streams not supported yet -- defaulting to read only");
@@ -549,27 +481,4 @@ void CALLBACK Helpers::TTFlushAndCloseStreamCallback(JsTTDStreamHandle handle, b
 {
     fflush(((PAL_FILE*)handle)->bsdFilePtr);
     fclose(((PAL_FILE*)handle)->bsdFilePtr);
-}
-
-void GetBinaryPathWithFileNameA(char *path, const size_t buffer_size, const char* filename)
-{
-    char fullpath[_MAX_PATH];
-    char drive[_MAX_DRIVE];
-    char dir[_MAX_DIR];
-
-    char modulename[_MAX_PATH];
-    PlatformAgnostic::SystemInfo::GetBinaryLocation(modulename, _MAX_PATH);
-    _splitpath_s(modulename, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
-    _makepath_s(fullpath, drive, dir, filename, nullptr);
-
-    size_t len = strlen(fullpath);
-    if (len < buffer_size)
-    {
-        memcpy(path, fullpath, len * sizeof(char));
-    }
-    else
-    {
-        len = 0;
-    }
-    path[len] = char(0);
 }

--- a/chakracore-cxx/bin/ch/Helpers.h
+++ b/chakracore-cxx/bin/ch/Helpers.h
@@ -13,8 +13,6 @@ public :
     static int32_t LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError = true);
 
     static void TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg);
-    static std::string CreateTTDDirectoryAsNeeded(const std::string& exeDir, const std::string& asciiDir1, const std::string& asciiDir2);
-    static std::string GetTTDDirectory(const std::string_view curi);
 
     static JsTTDStreamHandle CALLBACK TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write);
     static bool CALLBACK TTReadBytesFromStreamCallback(JsTTDStreamHandle handle, byte* buff, size_t size, size_t* readCount);

--- a/chakracore-cxx/bin/ch/Helpers.h
+++ b/chakracore-cxx/bin/ch/Helpers.h
@@ -13,8 +13,8 @@ public :
     static int32_t LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError = true);
 
     static void TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg);
-    static void CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char* asciiDir2);
-    static void GetTTDDirectory(const char* curi, size_t* uriLength, char* uri, size_t bufferLength);
+    static void CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const std::string& asciiDir1, const std::string& asciiDir2);
+    static void GetTTDDirectory(const std::string_view curi, size_t* uriLength, char* uri, size_t bufferLength);
 
     static JsTTDStreamHandle CALLBACK TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write);
     static bool CALLBACK TTReadBytesFromStreamCallback(JsTTDStreamHandle handle, byte* buff, size_t size, size_t* readCount);

--- a/chakracore-cxx/bin/ch/Helpers.h
+++ b/chakracore-cxx/bin/ch/Helpers.h
@@ -13,8 +13,8 @@ public :
     static int32_t LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError = true);
 
     static void TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg);
-    static void CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char16_t* asciiDir2);
-    static void GetTTDDirectory(const char16_t* curi, size_t* uriLength, char* uri, size_t bufferLength);
+    static void CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const char* asciiDir1, const char* asciiDir2);
+    static void GetTTDDirectory(const char* curi, size_t* uriLength, char* uri, size_t bufferLength);
 
     static JsTTDStreamHandle CALLBACK TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write);
     static bool CALLBACK TTReadBytesFromStreamCallback(JsTTDStreamHandle handle, byte* buff, size_t size, size_t* readCount);

--- a/chakracore-cxx/bin/ch/Helpers.h
+++ b/chakracore-cxx/bin/ch/Helpers.h
@@ -13,8 +13,8 @@ public :
     static int32_t LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError = true);
 
     static void TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg);
-    static void CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const std::string& asciiDir1, const std::string& asciiDir2);
-    static void GetTTDDirectory(const std::string_view curi, size_t* uriLength, char* uri, size_t bufferLength);
+    static std::string CreateTTDDirectoryAsNeeded(const std::string& exeDir, const std::string& asciiDir1, const std::string& asciiDir2);
+    static std::string GetTTDDirectory(const std::string_view curi);
 
     static JsTTDStreamHandle CALLBACK TTCreateStreamCallback(size_t uriLength, const char* uri, size_t asciiNameLength, const char* asciiName, bool read, bool write);
     static bool CALLBACK TTReadBytesFromStreamCallback(JsTTDStreamHandle handle, byte* buff, size_t size, size_t* readCount);

--- a/chakracore-cxx/bin/ch/WScriptJsrt.cpp
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.cpp
@@ -9,15 +9,7 @@
 #include <ctime>
 #include <ratio>
 
-#ifdef __valid
-#define TEMP_VALID __valid
-#undef __valid
-#endif
 #include <chrono>
-#ifdef TEMP_VALID
-#define __valid TEMP_VALID
-#undef TEMP_VALID
-#endif
 
 #if defined(_X86_) || defined(_M_IX86)
 #define CPU_ARCH_TEXT "x86"

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -111,7 +111,7 @@ static bool DummyJsSerializedScriptLoadUtf8Source(
     return true;
 }
 
-int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, JsValueRef bufferValue, char *fullPath, JsValueRef parserStateCache, const bool doTTRecord, const bool doTTReplay, const JsRuntimeHandle chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount)
+int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, JsValueRef bufferValue, char *fullPath, JsValueRef parserStateCache, const bool doTTRecord, const bool doTTReplay, const JsRuntimeHandle chRuntime, const std::string& ttUri, const uint32_t startEventCount)
 {
     int32_t hr = S_OK;
     MessageQueue * messageQueue = new MessageQueue();
@@ -266,7 +266,7 @@ int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLe
                 JsValueRef global = nullptr;
 
                 IfFailedReturn(ChakraRTInterface::JsCreatePropertyId("ttdLogURI", strlen("ttdLogURI"), &ttProperty));
-                IfFailedReturn(ChakraRTInterface::JsCreateString(ttUri, ttUriLength, &ttString));
+                IfFailedReturn(ChakraRTInterface::JsCreateString(ttUri.c_str(), ttUri.length(), &ttString));
                 IfFailedReturn(ChakraRTInterface::JsGetGlobalObject(&global));
 
                 IfFailedReturn(ChakraRTInterface::JsSetProperty(global, ttProperty, ttString, false));
@@ -454,7 +454,7 @@ Error:
     return hr;
 }
 
-int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
+int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const std::string& ttUri, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -479,7 +479,7 @@ int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileCon
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount));
 
     if (false)
     {
@@ -503,7 +503,7 @@ Error:
     return hr;
 }
 
-int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
+int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const std::string& ttUri, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -529,7 +529,7 @@ int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileCont
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount));
 
     if(false)
     {
@@ -594,7 +594,7 @@ int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const ch
     return e;
 }
 
-int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
+int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const std::string& ttUri, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
 {
     int32_t hr = S_OK;
     const char * fileContents = nullptr;
@@ -615,14 +615,14 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
 
         jsrtAttributes = static_cast<JsRuntimeAttributes>(jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
 
-        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(jsrtAttributes, ttUri, ttUriLength, Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
+        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(jsrtAttributes, ttUri.c_str(), ttUri.length(), Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
         chRuntime = runtime;
 
         JsContextRef context = JS_INVALID_REFERENCE;
         IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateContext(runtime, true, &context));
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(context));
 
-        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
+        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount));
 
         unsigned int rcount = 0;
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(nullptr));
@@ -714,7 +714,7 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         }
         else if (HostConfigFlags::flags.SerializedIsEnabled)
         {
-            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, jsrtAttributes);
+            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount, jsrtAttributes);
         }
         else if (HostConfigFlags::flags.GenerateParserStateCacheIsEnabled)
         {
@@ -722,11 +722,11 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         }
         else if (HostConfigFlags::flags.UseParserStateCacheIsEnabled)
         {
-            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, jsrtAttributes);
+            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount, jsrtAttributes);
         }
         else
         {
-            IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
+            IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, startEventCount));
         }
     }
 Error:
@@ -742,11 +742,11 @@ Error:
     return hr;
 }
 
-int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
+int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const std::string& ttUri, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
 {
     int32_t hr = E_FAIL;
     // REVIEW: Do we need a SEH handler here?
-    hr = ExecuteTest(fileName, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
+    hr = ExecuteTest(fileName, doTTRecord, doTTReplay, chRuntime, ttUri, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     if (FAILED(hr)) exit(0);
 
     fflush(NULL);
@@ -842,7 +842,7 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         }
 
         // On linux, execute on the same thread
-        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri.c_str(), ttUri.length(), snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
+        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     }
 
     PAL_Shutdown();

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -793,12 +793,6 @@ int32_t ExecuteTestWithMemoryCheck(char* fileName)
     return hr;
 }
 
-unsigned int WINAPI StaticThreadProc(void *lpParam)
-{
-    ChakraRTInterface::ArgInfo* argInfo = static_cast<ChakraRTInterface::ArgInfo* >(lpParam);
-    return ExecuteTestWithMemoryCheck(argInfo->filename);
-}
-
 static char16_t** argv = nullptr;
 int main_internal(int argc, char** c_argv)
 {

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -5,6 +5,9 @@
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
 #include "chhelper.h"
+
+#include <print>
+
 #include "chakra/src/lib.rs.h"
 #include <pthread.h>
 
@@ -126,12 +129,12 @@ int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLe
             fileContentsFinalizeCallback((void*)fileContents);
         }
 #if !ENABLE_TTD
-        PAL_wprintf(u"Sential js file is only ok when in TTDebug mode!!!\n");
+        std::println("Sential js file is only ok when in TTDebug mode!!!");
         return E_FAIL;
 #else
         if(!doTTReplay)
         {
-            PAL_wprintf(u"Sential js file is only ok when in TTReplay mode!!!\n");
+            std::println("Sential js file is only ok when in TTReplay mode!!!");
             return E_FAIL;
         }
 
@@ -151,7 +154,7 @@ int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLe
                 {
                     if(error == JsErrorCategoryUsage)
                     {
-                        PAL_wprintf(u"Start time not in log range.\n");
+                        std::println("Start time not in log range.");
                     }
 
                     return error;
@@ -164,21 +167,22 @@ int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLe
                 //handle any uncaught exception by immediately time-traveling to the throwing line in the debugger -- in replay just report and exit
                 if(res == JsErrorCategoryScript)
                 {
-                    PAL_wprintf(u"An unhandled script exception occurred!!!\n");
+                    std::println("An unhandled script exception occurred!!!");
 
                     exit(0);
                 }
 
                 if(nextEventTime == -1)
                 {
-                    PAL_wprintf(u"\nReached end of Execution -- Exiting.\n");
+                    std::println();
+                    std::println("Reached end of Execution -- Exiting.");
                     break;
                 }
             }
         }
         catch(...)
         {
-            PAL_wprintf(u"Terminal exception in Replay -- exiting.\n");
+            std::println("Terminal exception in Replay -- exiting.");
             exit(0);
         }
 #endif
@@ -281,7 +285,7 @@ int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLe
                 JsParseScriptAttributeNone, nullptr /*result*/);
             if (runScript == JsErrorCategoryUsage)
             {
-                PAL_wprintf(u"FATAL ERROR: Core was compiled without ENABLE_TTD is defined. CH is trying to use TTD interface\n");
+                std::println("FATAL ERROR: Core was compiled without ENABLE_TTD is defined. CH is trying to use TTD interface");
                 abort();
             }
 #else
@@ -604,12 +608,12 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
     if(strlen(fileName) >= 14 && strcmp(fileName + strlen(fileName) - 14, "ttdSentinal.js") == 0)
     {
 #if !ENABLE_TTD
-        PAL_wprintf(u"Sentinel js file is only ok when in TTDebug mode!!!\n");
+        std::println("Sentinel js file is only ok when in TTDebug mode!!!");
         return E_FAIL;
 #else
         if(!doTTReplay)
         {
-            PAL_wprintf(u"Sentinel js file is only ok when in TTReplay mode!!!\n");
+            std::println("Sentinel js file is only ok when in TTReplay mode!!!");
             return E_FAIL;
         }
 

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -777,7 +777,7 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
     bool doTTReplay = false;
     JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
 
-    std::string ttUri;
+    rust::String ttUri;
 
     for(int i = 1; i < argc; ++i)
     {
@@ -787,13 +787,13 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         {
             doTTRecord = true;
             char* ruri = c_argv[i] + strlen("-TTRecord=");
-            ttUri = Helpers::GetTTDDirectory(ruri);
+            ttUri = chakra::get_ttd_directory(ruri);
         }
         else if(arg.starts_with("-TTReplay="))
         {
             doTTReplay = true;
             char* ruri = c_argv[i] + strlen("-TTReplay=");
-            ttUri = Helpers::GetTTDDirectory(ruri);
+            ttUri = chakra::get_ttd_directory(ruri);
         }
         else if (arg.starts_with("-TTSnapInterval=")
             || arg.starts_with("-TTHistoryLength=")
@@ -842,7 +842,7 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         }
 
         // On linux, execute on the same thread
-        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
+        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, static_cast<std::string>(ttUri), snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     }
 
     PAL_Shutdown();

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -783,13 +783,13 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
     {
         std::string_view arg = c_argv[i];
 
-        if(PAL_wcsstr(argv[i], u"-TTRecord=") == argv[i])
+        if(arg.starts_with("-TTRecord="))
         {
             doTTRecord = true;
             char16_t* ruri = argv[i] + PAL_wcslen(u"-TTRecord=");
             Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
         }
-        else if(PAL_wcsstr(argv[i], u"-TTReplay=") == argv[i])
+        else if(arg.starts_with("-TTReplay="))
         {
             doTTReplay = true;
             char16_t* ruri = argv[i] + PAL_wcslen(u"-TTReplay=");

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -16,8 +16,6 @@
 
 unsigned int MessageBase::s_messageCount = 0;
 
-const char16_t* hostName = u"ch";
-
 const size_t ttUriBufferLength = MAX_PATH * 3;
 
 int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const char* fileName);

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -22,29 +22,6 @@ const size_t ttUriBufferLength = MAX_PATH * 3;
 
 int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const char* fileName);
 
-int HostExceptionFilter(int exceptionCode, _EXCEPTION_POINTERS *ep)
-{
-    ChakraRTInterface::NotifyUnhandledException(ep);
-
-    bool crashOnException = false;
-    ChakraRTInterface::GetCrashOnExceptionFlag(&crashOnException);
-
-    if (exceptionCode == EXCEPTION_BREAKPOINT || (crashOnException && exceptionCode != 0xE06D7363))
-    {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
-
-    PAL_fwprintf(PAL_get_stderr(), u"FATAL ERROR: %ls failed due to exception code %x\n", hostName, exceptionCode);
-
-    fflush(NULL);
-
-    // Exception happened, so we probably didn't clean up properly,
-    // Don't exit normally, just terminate
-    TerminateProcess(::GetCurrentProcess(), exceptionCode);
-
-    return EXCEPTION_CONTINUE_SEARCH;
-}
-
 // On success the param byteCodeBuffer will be allocated in the function.
 int32_t GetSerializedBuffer(const char * fileContents, JsFinalizeCallback fileContentFinalizeCallback, JsValueRef *byteCodeBuffer)
 {

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -761,7 +761,8 @@ int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const 
 }
 
 static char16_t** argv = nullptr;
-int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount)
+int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount,
+    const bool doTTRecord, const bool doTTReplay, rust::String ttUri)
 {
     int origargc = argc; // store for clean-up later
     argv = new char16_t*[argc];
@@ -777,35 +778,17 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
     ChakraRTInterface::ArgInfo argInfo;
 
     JsRuntimeHandle chRuntime = JS_INVALID_RUNTIME_HANDLE;
-    bool doTTRecord = false;
-    bool doTTReplay = false;
     JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
-
-    rust::String ttUri;
 
     for(int i = 1; i < argc; ++i)
     {
         std::string_view arg = c_argv[i];
 
-        if(arg.starts_with("-TTRecord="))
-        {
-            doTTRecord = true;
-            char* ruri = c_argv[i] + strlen("-TTRecord=");
-            ttUri = chakra::get_ttd_directory(ruri);
-        }
-        else if(arg.starts_with("-TTReplay="))
-        {
-            doTTReplay = true;
-            char* ruri = c_argv[i] + strlen("-TTReplay=");
-            ttUri = chakra::get_ttd_directory(ruri);
-        }
-        else if (arg.starts_with("-TTSnapInterval=")
+        if (!(arg.starts_with("-TTSnapInterval=")
             || arg.starts_with("-TTHistoryLength=")
-            || arg.starts_with("-TTDStartEvent="))
-        {
-            // parsed by rust
-        }
-        else
+            || arg.starts_with("-TTDStartEvent=")
+            || arg.starts_with("-TTReplay=")
+            || arg.starts_with("-TTRecord=")))
         {
             char16_t *temp = argv[cpos];
             argv[cpos] = argv[i];
@@ -814,12 +797,6 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         }
     }
     argc = cpos;
-
-    if(doTTRecord & doTTReplay)
-    {
-        PAL_fwprintf(PAL_get_stderr(), u"Cannot run in record and replay at same time!!!");
-        exit(0);
-    }
 
     HostConfigFlags::pfnPrintUsage = chakra::print_usage;
 

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -786,13 +786,13 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         if(arg.starts_with("-TTRecord="))
         {
             doTTRecord = true;
-            char16_t* ruri = argv[i] + PAL_wcslen(u"-TTRecord=");
+            char* ruri = c_argv[i] + strlen("-TTRecord=");
             Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
         }
         else if(arg.starts_with("-TTReplay="))
         {
             doTTReplay = true;
-            char16_t* ruri = argv[i] + PAL_wcslen(u"-TTReplay=");
+            char* ruri = c_argv[i] + strlen("-TTReplay=");
             Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
         }
         else if (arg.starts_with("-TTSnapInterval=")

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -759,7 +759,7 @@ int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const 
 }
 
 static char16_t** argv = nullptr;
-int main_internal(int argc, char** c_argv)
+int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount)
 {
     int origargc = argc; // store for clean-up later
     argv = new char16_t*[argc];
@@ -779,13 +779,12 @@ int main_internal(int argc, char** c_argv)
     bool doTTReplay = false;
     char ttUri[ttUriBufferLength];
     size_t ttUriLength = 0;
-    uint32_t snapInterval = MAXUINT32;
-    uint32_t snapHistoryLength = MAXUINT32;
-    uint32_t startEventCount = 1;
     JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
 
     for(int i = 1; i < argc; ++i)
     {
+        std::string_view arg = c_argv[i];
+
         if(PAL_wcsstr(argv[i], u"-TTRecord=") == argv[i])
         {
             doTTRecord = true;
@@ -798,20 +797,11 @@ int main_internal(int argc, char** c_argv)
             char16_t* ruri = argv[i] + PAL_wcslen(u"-TTReplay=");
             Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
         }
-        else if(PAL_wcsstr(argv[i], u"-TTSnapInterval=") == argv[i])
+        else if (arg.starts_with("-TTSnapInterval=")
+            || arg.starts_with("-TTHistoryLength=")
+            || arg.starts_with("-TTDStartEvent="))
         {
-            const char16_t* intervalStr = argv[i] + PAL_wcslen(u"-TTSnapInterval=");
-            snapInterval = (uint32_t)_wtoi(intervalStr);
-        }
-        else if(PAL_wcsstr(argv[i], u"-TTHistoryLength=") == argv[i])
-        {
-            const char16_t* historyStr = argv[i] + PAL_wcslen(u"-TTHistoryLength=");
-            snapHistoryLength = (uint32_t)_wtoi(historyStr);
-        }
-        else if(PAL_wcsstr(argv[i], u"-TTDStartEvent=") == argv[i])
-        {
-            const char16_t* startEventStr = argv[i] + PAL_wcslen(u"-TTDStartEvent=");
-            startEventCount = (uint32_t)_wtoi(startEventStr);
+            // parsed by rust
         }
         else
         {

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -454,7 +454,7 @@ Error:
     return hr;
 }
 
-int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle* chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
+int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -466,7 +466,7 @@ int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileCon
 
     // Bytecode buffer is created in one runtime and will be executed on different runtime.
     IfFailedGoLabel(CreateRuntime(&runtime, jsrtAttributes), ErrorRunFinalize);
-    *chRuntime = runtime;
+    chRuntime = runtime;
 
     IfJsErrorFailLogLabel(ChakraRTInterface::JsCreateContext(runtime, &context), ErrorRunFinalize);
     IfJsErrorFailLogLabel(ChakraRTInterface::JsGetCurrentContext(&current), ErrorRunFinalize);
@@ -479,7 +479,7 @@ int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileCon
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
 
     if (false)
     {
@@ -503,7 +503,7 @@ Error:
     return hr;
 }
 
-int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle *chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
+int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -516,7 +516,7 @@ int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileCont
     // Bytecode buffer is created in one runtime and will be executed on different runtime.
 
     IfFailedGoLabel(CreateRuntime(&runtime, jsrtAttributes), ErrorRunFinalize);
-    *chRuntime = runtime;
+    chRuntime = runtime;
 
     IfJsErrorFailLogLabel(ChakraRTInterface::JsCreateContext(runtime, &context), ErrorRunFinalize);
     IfJsErrorFailLogLabel(ChakraRTInterface::JsGetCurrentContext(&current), ErrorRunFinalize);
@@ -529,7 +529,7 @@ int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileCont
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
 
     if(false)
     {
@@ -594,7 +594,7 @@ int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const ch
     return e;
 }
 
-int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle* chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes* jsrtAttributes)
+int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
 {
     int32_t hr = S_OK;
     const char * fileContents = nullptr;
@@ -613,16 +613,16 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
             return E_FAIL;
         }
 
-        *jsrtAttributes = static_cast<JsRuntimeAttributes>(*jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
+        jsrtAttributes = static_cast<JsRuntimeAttributes>(jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
 
-        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(*jsrtAttributes, ttUri, ttUriLength, Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
-        *chRuntime = runtime;
+        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(jsrtAttributes, ttUri, ttUriLength, Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
+        chRuntime = runtime;
 
         JsContextRef context = JS_INVALID_REFERENCE;
         IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateContext(runtime, true, &context));
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(context));
 
-        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
+        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
 
         unsigned int rcount = 0;
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(nullptr));
@@ -643,17 +643,17 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         IfFailGo(hr);
         if (HostConfigFlags::flags.GenerateLibraryByteCodeHeaderIsEnabled)
         {
-            *jsrtAttributes = (JsRuntimeAttributes)(*jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
+            jsrtAttributes = (JsRuntimeAttributes)(jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
         }
 
 #if ENABLE_TTD
         if (doTTRecord)
         {
             //Ensure we run with experimental features (as that is what Node does right now).
-            *jsrtAttributes = static_cast<JsRuntimeAttributes>(*jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
+            jsrtAttributes = static_cast<JsRuntimeAttributes>(jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
 
-            IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateRecordRuntime(*jsrtAttributes, snapInterval, snapHistoryLength, Helpers::TTCreateStreamCallback, Helpers::TTWriteBytesToStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
-            *chRuntime = runtime;
+            IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateRecordRuntime(jsrtAttributes, snapInterval, snapHistoryLength, Helpers::TTCreateStreamCallback, Helpers::TTWriteBytesToStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
+            chRuntime = runtime;
 
             JsContextRef context = JS_INVALID_REFERENCE;
             IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateContext(runtime, true, &context));
@@ -669,8 +669,8 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         {
             AssertMsg(!doTTReplay, "Should be handled in the else case above!!!");
 
-            IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(*jsrtAttributes, nullptr, &runtime));
-            *chRuntime = runtime;
+            IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(jsrtAttributes, nullptr, &runtime));
+            chRuntime = runtime;
 
             JsContextRef context = JS_INVALID_REFERENCE;
             IfJsErrorFailLog(ChakraRTInterface::JsCreateContext(runtime, &context));
@@ -714,7 +714,7 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         }
         else if (HostConfigFlags::flags.SerializedIsEnabled)
         {
-            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, *jsrtAttributes);
+            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, jsrtAttributes);
         }
         else if (HostConfigFlags::flags.GenerateParserStateCacheIsEnabled)
         {
@@ -722,7 +722,7 @@ int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTT
         }
         else if (HostConfigFlags::flags.UseParserStateCacheIsEnabled)
         {
-            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, *jsrtAttributes);
+            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, jsrtAttributes);
         }
         else
         {
@@ -742,7 +742,7 @@ Error:
     return hr;
 }
 
-int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle *chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes *jsrtAttributes)
+int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle &chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes &jsrtAttributes)
 {
     int32_t hr = E_FAIL;
     // REVIEW: Do we need a SEH handler here?
@@ -842,7 +842,7 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         }
 
         // On linux, execute on the same thread
-        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, &chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, &jsrtAttributes);
+        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     }
 
     PAL_Shutdown();

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -18,21 +18,9 @@ unsigned int MessageBase::s_messageCount = 0;
 
 const char16_t* hostName = u"ch";
 
-JsRuntimeHandle chRuntime = JS_INVALID_RUNTIME_HANDLE;
-
-bool doTTRecord = false;
-bool doTTReplay = false;
 const size_t ttUriBufferLength = MAX_PATH * 3;
-char ttUri[ttUriBufferLength];
-size_t ttUriLength = 0;
-uint32_t snapInterval = MAXUINT32;
-uint32_t snapHistoryLength = MAXUINT32;
-const char16_t* connectionUuidString = NULL;
-uint32_t startEventCount = 1;
 
 int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const char* fileName);
-
-JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
 
 int HostExceptionFilter(int exceptionCode, _EXCEPTION_POINTERS *ep)
 {
@@ -148,7 +136,7 @@ static bool DummyJsSerializedScriptLoadUtf8Source(
     return true;
 }
 
-int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, JsValueRef bufferValue, char *fullPath, JsValueRef parserStateCache)
+int32_t RunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, JsValueRef bufferValue, char *fullPath, JsValueRef parserStateCache, const bool doTTRecord, const bool doTTReplay, const JsRuntimeHandle chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount)
 {
     int32_t hr = S_OK;
     MessageQueue * messageQueue = new MessageQueue();
@@ -388,7 +376,7 @@ Error:
     return hr;
 }
 
-static int32_t CreateRuntime(JsRuntimeHandle *runtime)
+static int32_t CreateRuntime(JsRuntimeHandle *runtime, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = E_FAIL;
 
@@ -491,7 +479,7 @@ Error:
     return hr;
 }
 
-int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath)
+int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle* chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -502,8 +490,8 @@ int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileCon
     IfFailedGoLabel(GetParserStateBuffer(fileContents, nullptr, &bufferVal), ErrorRunFinalize);
 
     // Bytecode buffer is created in one runtime and will be executed on different runtime.
-    IfFailedGoLabel(CreateRuntime(&runtime), ErrorRunFinalize);
-    chRuntime = runtime;
+    IfFailedGoLabel(CreateRuntime(&runtime, jsrtAttributes), ErrorRunFinalize);
+    *chRuntime = runtime;
 
     IfJsErrorFailLogLabel(ChakraRTInterface::JsCreateContext(runtime, &context), ErrorRunFinalize);
     IfJsErrorFailLogLabel(ChakraRTInterface::JsGetCurrentContext(&current), ErrorRunFinalize);
@@ -516,7 +504,7 @@ int32_t CreateParserStateAndRunScript(const char* fileName, const char * fileCon
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, nullptr, fullPath, bufferVal, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
 
     if (false)
     {
@@ -540,7 +528,7 @@ Error:
     return hr;
 }
 
-int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath)
+int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileContents, size_t fileLength, JsFinalizeCallback fileContentsFinalizeCallback, char *fullPath, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle *chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t startEventCount, const JsRuntimeAttributes jsrtAttributes)
 {
     int32_t hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -552,8 +540,8 @@ int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileCont
 
     // Bytecode buffer is created in one runtime and will be executed on different runtime.
 
-    IfFailedGoLabel(CreateRuntime(&runtime), ErrorRunFinalize);
-    chRuntime = runtime;
+    IfFailedGoLabel(CreateRuntime(&runtime, jsrtAttributes), ErrorRunFinalize);
+    *chRuntime = runtime;
 
     IfJsErrorFailLogLabel(ChakraRTInterface::JsCreateContext(runtime, &context), ErrorRunFinalize);
     IfJsErrorFailLogLabel(ChakraRTInterface::JsGetCurrentContext(&current), ErrorRunFinalize);
@@ -566,7 +554,7 @@ int32_t CreateAndRunSerializedScript(const char* fileName, const char * fileCont
     }
 
     // This is our last call to use fileContents, so pass in the finalizeCallback
-    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr));
+    IfFailGo(RunScript(fileName, fileContents, fileLength, fileContentsFinalizeCallback, bufferVal, fullPath, nullptr, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
 
     if(false)
     {
@@ -631,7 +619,7 @@ int32_t RunBgParseSync(const char * fileContents, uint32_t lengthBytes, const ch
     return e;
 }
 
-int32_t ExecuteTest(const char* fileName)
+int32_t ExecuteTest(const char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle* chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes* jsrtAttributes)
 {
     int32_t hr = S_OK;
     const char * fileContents = nullptr;
@@ -650,16 +638,16 @@ int32_t ExecuteTest(const char* fileName)
             return E_FAIL;
         }
 
-        jsrtAttributes = static_cast<JsRuntimeAttributes>(jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
+        *jsrtAttributes = static_cast<JsRuntimeAttributes>(*jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
 
-        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(jsrtAttributes, ttUri, ttUriLength, Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
-        chRuntime = runtime;
+        IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateReplayRuntime(*jsrtAttributes, ttUri, ttUriLength, Helpers::TTCreateStreamCallback, Helpers::TTReadBytesFromStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
+        *chRuntime = runtime;
 
         JsContextRef context = JS_INVALID_REFERENCE;
         IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateContext(runtime, true, &context));
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(context));
 
-        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr));
+        IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, nullptr, nullptr, doTTRecord, doTTReplay, *chRuntime, ttUri, ttUriLength, startEventCount));
 
         unsigned int rcount = 0;
         IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(nullptr));
@@ -680,17 +668,17 @@ int32_t ExecuteTest(const char* fileName)
         IfFailGo(hr);
         if (HostConfigFlags::flags.GenerateLibraryByteCodeHeaderIsEnabled)
         {
-            jsrtAttributes = (JsRuntimeAttributes)(jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
+            *jsrtAttributes = (JsRuntimeAttributes)(*jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
         }
 
 #if ENABLE_TTD
         if (doTTRecord)
         {
             //Ensure we run with experimental features (as that is what Node does right now).
-            jsrtAttributes = static_cast<JsRuntimeAttributes>(jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
+            *jsrtAttributes = static_cast<JsRuntimeAttributes>(*jsrtAttributes | JsRuntimeAttributeEnableExperimentalFeatures);
 
-            IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateRecordRuntime(jsrtAttributes, snapInterval, snapHistoryLength, Helpers::TTCreateStreamCallback, Helpers::TTWriteBytesToStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
-            chRuntime = runtime;
+            IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateRecordRuntime(*jsrtAttributes, snapInterval, snapHistoryLength, Helpers::TTCreateStreamCallback, Helpers::TTWriteBytesToStreamCallback, Helpers::TTFlushAndCloseStreamCallback, nullptr, &runtime));
+            *chRuntime = runtime;
 
             JsContextRef context = JS_INVALID_REFERENCE;
             IfJsErrorFailLog(ChakraRTInterface::JsTTDCreateContext(runtime, true, &context));
@@ -706,8 +694,8 @@ int32_t ExecuteTest(const char* fileName)
         {
             AssertMsg(!doTTReplay, "Should be handled in the else case above!!!");
 
-            IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(jsrtAttributes, nullptr, &runtime));
-            chRuntime = runtime;
+            IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(*jsrtAttributes, nullptr, &runtime));
+            *chRuntime = runtime;
 
             JsContextRef context = JS_INVALID_REFERENCE;
             IfJsErrorFailLog(ChakraRTInterface::JsCreateContext(runtime, &context));
@@ -751,7 +739,7 @@ int32_t ExecuteTest(const char* fileName)
         }
         else if (HostConfigFlags::flags.SerializedIsEnabled)
         {
-            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath);
+            CreateAndRunSerializedScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, *jsrtAttributes);
         }
         else if (HostConfigFlags::flags.GenerateParserStateCacheIsEnabled)
         {
@@ -759,11 +747,11 @@ int32_t ExecuteTest(const char* fileName)
         }
         else if (HostConfigFlags::flags.UseParserStateCacheIsEnabled)
         {
-            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath);
+            CreateParserStateAndRunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, fullPath, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount, *jsrtAttributes);
         }
         else
         {
-            IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr));
+            IfFailGo(RunScript(fileName, fileContents, lengthBytes, WScriptJsrt::FinalizeFree, nullptr, fullPath, nullptr, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, startEventCount));
         }
     }
 Error:
@@ -779,11 +767,11 @@ Error:
     return hr;
 }
 
-int32_t ExecuteTestWithMemoryCheck(char* fileName)
+int32_t ExecuteTestWithMemoryCheck(char* fileName, const bool doTTRecord, const bool doTTReplay, JsRuntimeHandle *chRuntime, const char *ttUri, const size_t ttUriLength, const uint32_t snapInterval, const uint32_t snapHistoryLength, const uint32_t startEventCount, JsRuntimeAttributes *jsrtAttributes)
 {
     int32_t hr = E_FAIL;
     // REVIEW: Do we need a SEH handler here?
-    hr = ExecuteTest(fileName);
+    hr = ExecuteTest(fileName, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     if (FAILED(hr)) exit(0);
 
     fflush(NULL);
@@ -808,6 +796,16 @@ int main_internal(int argc, char** c_argv)
     int cpos = 1;
     bool success = false;
     ChakraRTInterface::ArgInfo argInfo;
+
+    JsRuntimeHandle chRuntime = JS_INVALID_RUNTIME_HANDLE;
+    bool doTTRecord = false;
+    bool doTTReplay = false;
+    char ttUri[ttUriBufferLength];
+    size_t ttUriLength = 0;
+    uint32_t snapInterval = MAXUINT32;
+    uint32_t snapHistoryLength = MAXUINT32;
+    uint32_t startEventCount = 1;
+    JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
 
     for(int i = 1; i < argc; ++i)
     {
@@ -879,7 +877,7 @@ int main_internal(int argc, char** c_argv)
         }
 
         // On linux, execute on the same thread
-        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename);
+        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, &chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, &jsrtAttributes);
     }
 
     PAL_Shutdown();

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -775,9 +775,9 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
     JsRuntimeHandle chRuntime = JS_INVALID_RUNTIME_HANDLE;
     bool doTTRecord = false;
     bool doTTReplay = false;
-    char ttUri[ttUriBufferLength];
-    size_t ttUriLength = 0;
     JsRuntimeAttributes jsrtAttributes = JsRuntimeAttributeNone;
+
+    std::string ttUri;
 
     for(int i = 1; i < argc; ++i)
     {
@@ -787,13 +787,13 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         {
             doTTRecord = true;
             char* ruri = c_argv[i] + strlen("-TTRecord=");
-            Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
+            ttUri = Helpers::GetTTDDirectory(ruri);
         }
         else if(arg.starts_with("-TTReplay="))
         {
             doTTReplay = true;
             char* ruri = c_argv[i] + strlen("-TTReplay=");
-            Helpers::GetTTDDirectory(ruri, &ttUriLength, ttUri, ttUriBufferLength);
+            ttUri = Helpers::GetTTDDirectory(ruri);
         }
         else if (arg.starts_with("-TTSnapInterval=")
             || arg.starts_with("-TTHistoryLength=")
@@ -842,7 +842,7 @@ int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapH
         }
 
         // On linux, execute on the same thread
-        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri, ttUriLength, snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
+        exitCode = ExecuteTestWithMemoryCheck(argInfo.filename, doTTRecord, doTTReplay, chRuntime, ttUri.c_str(), ttUri.length(), snapInterval, snapHistoryLength, startEventCount, jsrtAttributes);
     }
 
     PAL_Shutdown();

--- a/chakracore-cxx/bin/ch/chhelper.cpp
+++ b/chakracore-cxx/bin/ch/chhelper.cpp
@@ -811,23 +811,6 @@ int main_internal(int argc, char** c_argv)
 
     for(int i = 1; i < argc; ++i)
     {
-        const char16_t *arg = argv[i];
-        size_t arglen = PAL_wcslen(arg);
-
-        // support - prefix for flags
-        if (arglen >= 1 && arg[0] == u'-')
-        {
-            // support -- prefix for flags
-            if (arglen >= 2 && arg[0] == u'-' && arg[1] == u'-')
-            {
-                arg += 2; // advance past -- prefix
-            }
-            else
-            {
-                arg += 1; // advance past - prefix
-            }
-        }
-
         if(PAL_wcsstr(argv[i], u"-TTRecord=") == argv[i])
         {
             doTTRecord = true;

--- a/chakracore-cxx/bin/ch/chhelper.h
+++ b/chakracore-cxx/bin/ch/chhelper.h
@@ -1,1 +1,4 @@
-int main_internal(int argc, char** c_argv);
+#pragma once
+#include <cstdint>
+
+int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount);

--- a/chakracore-cxx/bin/ch/chhelper.h
+++ b/chakracore-cxx/bin/ch/chhelper.h
@@ -1,4 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "rust/cxx.h"
 
-int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount);
+int main_internal(int argc, char** c_argv, uint32_t snapInterval, uint32_t snapHistoryLength, uint32_t startEventCount,
+    const bool doTTRecord, const bool doTTReplay, rust::String ttUri);

--- a/chakracore-cxx/bin/ch/stdafx.h
+++ b/chakracore-cxx/bin/ch/stdafx.h
@@ -339,5 +339,3 @@ inline JsErrorCode CreatePropertyIdFromString(const char* str, JsPropertyIdRef *
 {
     return ChakraRTInterface::JsCreatePropertyId(str, strlen(str), Id);
 }
-
-void GetBinaryPathWithFileNameA(char *path, const size_t buffer_size, const char* filename);

--- a/chakracore-cxx/pal/inc/rt/sal.h
+++ b/chakracore-cxx/pal/inc/rt/sal.h
@@ -1764,7 +1764,6 @@ extern "C" {
     #define __readonly
     #define __notreadonly
     #define __maybereadonly
-    #define __valid
     #define __notvalid
     #define __maybevalid
     #define __readableTo(extent)
@@ -1822,18 +1821,18 @@ buffer, use the table in the buffer annotations section.
 #define __out_bcount_part(size,length)                           _SAL1_Source_(__out_bcount_part, (size,length), _Out_writes_bytes_to_(size,length))
 #define __out_ecount_full(size)                                  _SAL1_Source_(__out_ecount_full, (size), _Out_writes_all_(size))
 #define __out_bcount_full(size)                                  _SAL1_Source_(__out_bcount_full, (size), _Out_writes_bytes_all_(size))
-#define __out_z                                                  _SAL1_Source_(__out_z, (), __post __valid __refparam __post __nullterminated)
-#define __out_z_opt                                              _SAL1_Source_(__out_z_opt, (), __post __valid __refparam __post __nullterminated __pre_except_maybenull)
-#define __out_ecount_z(size)                                     _SAL1_Source_(__out_ecount_z, (size), __ecount(size) __post __valid __refparam __post __nullterminated)
-#define __out_bcount_z(size)                                     _SAL1_Source_(__out_bcount_z, (size), __bcount(size) __post __valid __refparam __post __nullterminated)
+#define __out_z                                                  _SAL1_Source_(__out_z, (), __post __refparam __post __nullterminated)
+#define __out_z_opt                                              _SAL1_Source_(__out_z_opt, (), __post __refparam __post __nullterminated __pre_except_maybenull)
+#define __out_ecount_z(size)                                     _SAL1_Source_(__out_ecount_z, (size), __ecount(size) __post __refparam __post __nullterminated)
+#define __out_bcount_z(size)                                     _SAL1_Source_(__out_bcount_z, (size), __bcount(size) __post __refparam __post __nullterminated)
 #define __out_ecount_part_z(size,length)                         _SAL1_Source_(__out_ecount_part_z, (size,length), __out_ecount_part(size,length) __post __nullterminated)
 #define __out_bcount_part_z(size,length)                         _SAL1_Source_(__out_bcount_part_z, (size,length), __out_bcount_part(size,length) __post __nullterminated)
 #define __out_ecount_full_z(size)                                _SAL1_Source_(__out_ecount_full_z, (size), __out_ecount_full(size) __post __nullterminated)
 #define __out_bcount_full_z(size)                                _SAL1_Source_(__out_bcount_full_z, (size), __out_bcount_full(size) __post __nullterminated)
-#define __out_nz                                                 _SAL1_Source_(__out_nz, (), __post __valid __refparam)
-#define __out_nz_opt                                             _SAL1_Source_(__out_nz_opt, (), __post __valid __refparam __post_except_maybenull_)
-#define __out_ecount_nz(size)                                    _SAL1_Source_(__out_ecount_nz, (size), __ecount(size) __post __valid __refparam)
-#define __out_bcount_nz(size)                                    _SAL1_Source_(__out_bcount_nz, (size), __bcount(size) __post __valid __refparam)
+#define __out_nz                                                 _SAL1_Source_(__out_nz, (), __post __refparam)
+#define __out_nz_opt                                             _SAL1_Source_(__out_nz_opt, (), __post __refparam __post_except_maybenull_)
+#define __out_ecount_nz(size)                                    _SAL1_Source_(__out_ecount_nz, (size), __ecount(size) __post __refparam)
+#define __out_bcount_nz(size)                                    _SAL1_Source_(__out_bcount_nz, (size), __bcount(size) __post __refparam)
 #define __inout                                                  _SAL1_Source_(__inout, (), _Inout_)
 #define __inout_ecount(size)                                     _SAL1_Source_(__inout_ecount, (size), _Inout_updates_(size))
 #define __inout_bcount(size)                                     _SAL1_Source_(__inout_bcount, (size), _Inout_updates_bytes_(size))
@@ -1902,7 +1901,7 @@ buffer, use the table in the buffer annotations section.
 #define __deref_out_nz                                           _SAL1_Source_(__deref_out_nz, (), __deref_out)
 #define __deref_out_ecount_nz(size)                              _SAL1_Source_(__deref_out_ecount_nz, (size), __deref_out_ecount(size))
 #define __deref_out_bcount_nz(size)                              _SAL1_Source_(__deref_out_bcount_nz, (size), __deref_out_ecount(size))
-#define __deref_inout                                            _SAL1_Source_(__deref_inout, (), _Notref_ __notnull _Notref_ __elem_readableTo(1) __pre __deref __valid __post _Notref_ __deref __valid __refparam)
+#define __deref_inout                                            _SAL1_Source_(__deref_inout, (), _Notref_ __notnull _Notref_ __elem_readableTo(1) __pre __deref __post _Notref_ __deref __refparam)
 #define __deref_inout_z                                          _SAL1_Source_(__deref_inout_z, (), __deref_inout __pre __deref __nullterminated __post _Notref_ __deref __nullterminated)
 #define __deref_inout_ecount(size)                               _SAL1_Source_(__deref_inout_ecount, (size), __deref_inout __pre __deref __elem_writableTo(size) __post _Notref_ __deref __elem_writableTo(size))
 #define __deref_inout_bcount(size)                               _SAL1_Source_(__deref_inout_bcount, (size), __deref_inout __pre __deref __byte_writableTo(size) __post _Notref_ __deref __byte_writableTo(size))
@@ -1975,7 +1974,7 @@ buffer, use the table in the buffer annotations section.
 #define __deref_opt_out_bcount_part_opt(size,length)             _SAL1_Source_(__deref_opt_out_bcount_part_opt, (size,length), __deref_out_bcount_part_opt(size,length)    __pre_except_maybenull)
 #define __deref_opt_out_ecount_full_opt(size)                    _SAL1_Source_(__deref_opt_out_ecount_full_opt, (size), __deref_out_ecount_full_opt(size)           __pre_except_maybenull)
 #define __deref_opt_out_bcount_full_opt(size)                    _SAL1_Source_(__deref_opt_out_bcount_full_opt, (size), __deref_out_bcount_full_opt(size)           __pre_except_maybenull)
-#define __deref_opt_out_z_opt                                    _SAL1_Source_(__deref_opt_out_z_opt, (), __post __deref __valid __refparam __pre_except_maybenull __pre_deref_except_maybenull __post_deref_except_maybenull __post __deref __nullterminated)
+#define __deref_opt_out_z_opt                                    _SAL1_Source_(__deref_opt_out_z_opt, (), __post __deref __refparam __pre_except_maybenull __pre_deref_except_maybenull __post_deref_except_maybenull __post __deref __nullterminated)
 #define __deref_opt_out_ecount_z_opt(size)                       _SAL1_Source_(__deref_opt_out_ecount_z_opt, (size), __deref_opt_out_ecount_opt(size) __post __deref __nullterminated)
 #define __deref_opt_out_bcount_z_opt(size)                       _SAL1_Source_(__deref_opt_out_bcount_z_opt, (size), __deref_opt_out_bcount_opt(size) __post __deref __nullterminated)
 #define __deref_opt_out_nz_opt                                   _SAL1_Source_(__deref_opt_out_nz_opt, (), __deref_opt_out_opt)

--- a/chakracore-cxx/pal/inc/rt/specstrings.h
+++ b/chakracore-cxx/pal/inc/rt/specstrings.h
@@ -55,8 +55,8 @@ extern "C" {
 
 #define __xcount(size)                                          __notnull __inexpressible_writableTo(size)
 #define __in_xcount(size)                                       _Pre_ __inexpressible_readableTo(size)
-#define __out_xcount(size)                                      __xcount(size) _Post_ __valid __refparam
-#define __inout_xcount(size)                                    __out_xcount(size) _Pre_ __valid
+#define __out_xcount(size)                                      __xcount(size) _Post_ __refparam
+#define __inout_xcount(size)                                    __out_xcount(size) _Pre_
 
 #endif  //__SAL_H_FULL_VER <= 140050727
 

--- a/chakracore-sys/build.rs
+++ b/chakracore-sys/build.rs
@@ -48,7 +48,7 @@ fn main() {
                     .define("ICU_INCLUDE_PATH", "/opt/homebrew/opt/icu4c@77/include");
             }
 
-            config.always_configure(true);
+            config.always_configure(false);
             let dst = config.build();
             println!("cargo::rustc-link-search=native={}/lib", dst.display());
         }

--- a/chakracore-sys/src/chhelper.rs
+++ b/chakracore-sys/src/chhelper.rs
@@ -3,6 +3,12 @@ pub mod ffi {
     extern "C++" {
         include!("chhelper.h");
 
-        unsafe fn main_internal(argc: i32, argv: *mut *mut c_char) -> i32;
+        unsafe fn main_internal(
+            argc: i32,
+            argv: *mut *mut c_char,
+            snap_interval: u32,
+            snap_history_length: u32,
+            start_event_count: u32,
+        ) -> i32;
     }
 }

--- a/chakracore-sys/src/chhelper.rs
+++ b/chakracore-sys/src/chhelper.rs
@@ -9,6 +9,9 @@ pub mod ffi {
             snap_interval: u32,
             snap_history_length: u32,
             start_event_count: u32,
+            do_tt_record: bool,
+            do_tt_replay: bool,
+            tt_uri: String,
         ) -> i32;
     }
 }

--- a/chakracore/src/main.rs
+++ b/chakracore/src/main.rs
@@ -20,6 +20,11 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    if chakra_args.do_tt_record && chakra_args.do_tt_replay {
+        eprintln!("Cannot run in record and replay at same time!!!");
+        return ExitCode::SUCCESS;
+    }
+
     let args: Vec<CString> = std::env::args_os()
         .map(|os_str| {
             let bytes = os_str.as_bytes();
@@ -46,6 +51,9 @@ fn main() -> ExitCode {
             chakra_args.tt_snap_interval,
             chakra_args.tt_snap_history_length,
             chakra_args.ttd_start_event_count,
+            chakra_args.do_tt_record,
+            chakra_args.do_tt_replay,
+            chakra_args.tt_uri,
         );
         ExitCode::from(res as u8)
     }

--- a/chakracore/src/main.rs
+++ b/chakracore/src/main.rs
@@ -40,7 +40,13 @@ fn main() -> ExitCode {
     argv.push(ptr::null_mut());
 
     unsafe {
-        let res = chakracore_sys::chhelper::ffi::main_internal(argc as i32, argv.as_mut_ptr());
+        let res = chakracore_sys::chhelper::ffi::main_internal(
+            argc as i32,
+            argv.as_mut_ptr(),
+            chakra_args.tt_snap_interval,
+            chakra_args.tt_snap_history_length,
+            chakra_args.ttd_start_event_count,
+        );
         ExitCode::from(res as u8)
     }
 }


### PR DESCRIPTION
- no global vars in chhelper
- update to gcc14 and use std::print
- flags previously parsed in chhelper are now parsed in rust and passed to C++ as args (all were TTD params)