### PR TITLE
clean up warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,8 @@
 [alias]
 b = "build --features compile-cpp"
 bt = "build --features compile-cpp,optimized-tests"
+tb = "b --tests"
+ttb = "bt --tests"
 ct = "check --features optimized-tests"
 r = "run --features compile-cpp"
 t = "test --features compile-cpp"

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -185,8 +185,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")
 # recognized by older compilers and they fail. So, put this one and not fail
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-    -fno-omit-frame-pointer \
-    -fdelayed-template-parsing"
+    -fno-omit-frame-pointer"
 )
 
 # CXX / CC COMPILER FLAGS

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -156,9 +156,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-nontrivial-memcall"
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-    -Wno-reorder-ctor")
-
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")
 

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -151,8 +151,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-int-to-pointer-cast\
     -Wno-tautological-constant-compare\
     -Wno-enum-compare-switch\
-    -Wno-delayed-template-parsing-in-cxx20\
-    -Wno-unknown-warning-option"
+    -Wno-delayed-template-parsing-in-cxx20"
 )
 
 # this keeps causing issues with the docker build even if paths are correct

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -150,7 +150,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-switch\
     -Wno-int-to-pointer-cast\
     -Wno-tautological-constant-compare\
-    -Wno-enum-compare-switch\
     -Wno-delayed-template-parsing-in-cxx20"
 )
 

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -149,7 +149,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-return-type\
     -Wno-switch\
     -Wno-int-to-pointer-cast\
-    -Wno-tautological-constant-compare\
     -Wno-delayed-template-parsing-in-cxx20"
 )
 

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -160,8 +160,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-reorder-ctor\
     -Wno-unused-variable\
     -Wno-overloaded-virtual\
-    -Wno-unused-private-field\
-    -Wno-unused-but-set-variable")
+    -Wno-unused-private-field")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -163,7 +163,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-unused-private-field\
     -Wno-unused-but-set-variable\
     -Wno-unused-lambda-capture\
-    -Wno-sometimes-uninitialized\
     -Wno-tautological-overlap-compare")
 
 # this keeps causing issues with the docker build even if paths are correct

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -157,8 +157,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-    -Wno-reorder-ctor\
-    -Wno-unused-variable")
+    -Wno-reorder-ctor")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -132,7 +132,6 @@ add_definitions(
 # CXX WARNING FLAGS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wall\
-    -Wno-unused-value\
     -Wno-int-to-void-pointer-cast\
     -Wno-invalid-offsetof\
     -Wno-undefined-inline\

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -162,8 +162,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-overloaded-virtual\
     -Wno-unused-private-field\
     -Wno-unused-but-set-variable\
-    -Wno-unused-lambda-capture\
-    -Wno-tautological-overlap-compare")
+    -Wno-unused-lambda-capture")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -161,8 +161,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-unused-variable\
     -Wno-overloaded-virtual\
     -Wno-unused-private-field\
-    -Wno-unused-but-set-variable\
-    -Wno-unused-lambda-capture")
+    -Wno-unused-but-set-variable")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -148,7 +148,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-null-conversion\
     -Wno-return-type\
     -Wno-switch\
-    -Wno-int-to-pointer-cast\
     -Wno-delayed-template-parsing-in-cxx20"
 )
 

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -152,8 +152,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-tautological-constant-compare\
     -Wno-enum-compare-switch\
     -Wno-delayed-template-parsing-in-cxx20\
-    -Wno-unknown-warning-option\
-    -Wno-nontrivial-memcall"
+    -Wno-unknown-warning-option"
 )
 
 # this keeps causing issues with the docker build even if paths are correct

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -158,8 +158,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-reorder-ctor\
-    -Wno-unused-variable\
-    -Wno-overloaded-virtual")
+    -Wno-unused-variable")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -159,8 +159,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -Wno-reorder-ctor\
     -Wno-unused-variable\
-    -Wno-overloaded-virtual\
-    -Wno-unused-private-field")
+    -Wno-overloaded-virtual")
 
 # this keeps causing issues with the docker build even if paths are correct
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nonportable-include-path")

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -38,6 +38,7 @@ target_compile_options(chhelper PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(chhelper PUBLIC
 target_compile_options(chhelper PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(chhelper PRIVATE
     -Wno-unused-value
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -32,4 +32,6 @@ target_compile_definitions(chhelper PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(chhelper PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -32,6 +32,8 @@ target_compile_definitions(chhelper PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(chhelper PRIVATE -fdelayed-template-parsing)
+target_compile_options(chhelper PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_options(chhelper PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/bin/ch/CMakeLists.txt
+++ b/chakracore-cxx/bin/ch/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(chhelper PUBLIC
 
 target_compile_options(chhelper PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(chhelper PUBLIC stdafx.h)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -138,4 +138,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-tautological-overlap-compare
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -133,4 +133,5 @@ target_compile_definitions(Chakra.Backend PUBLIC
 
 target_compile_options(Chakra.Backend PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-sometimes-uninitialized)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -137,4 +137,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-sometimes-uninitialized
     -Wno-tautological-overlap-compare
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -140,4 +140,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -139,4 +139,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -142,4 +142,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-overloaded-virtual
     -Wno-unused-variable
     -Wno-reorder-ctor
-    -Wno-enum-compare-switch)
+    -Wno-enum-compare-switch
+    -Wno-int-to-pointer-cast)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -141,4 +141,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-unused-private-field
     -Wno-overloaded-virtual
     -Wno-unused-variable
-    -Wno-reorder-ctor)
+    -Wno-reorder-ctor
+    -Wno-enum-compare-switch)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -134,4 +134,5 @@ target_compile_definitions(Chakra.Backend PUBLIC
 target_compile_options(Chakra.Backend PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-sometimes-uninitialized)
+    -Wno-sometimes-uninitialized
+    -Wno-tautological-overlap-compare)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -131,4 +131,6 @@ target_compile_definitions(Chakra.Backend PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Backend PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Backend PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -136,4 +136,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -Wno-unused-value
     -Wno-sometimes-uninitialized
     -Wno-tautological-overlap-compare
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -135,4 +135,5 @@ target_compile_options(Chakra.Backend PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-sometimes-uninitialized
-    -Wno-tautological-overlap-compare)
+    -Wno-tautological-overlap-compare
+    -Wno-unused-lambda-capture)

--- a/chakracore-cxx/lib/Backend/CMakeLists.txt
+++ b/chakracore-cxx/lib/Backend/CMakeLists.txt
@@ -130,3 +130,5 @@ target_include_directories (Chakra.Backend PUBLIC
 target_compile_definitions(Chakra.Backend PUBLIC
     PAL_STDCPP_COMPAT
 )
+
+target_compile_options(Chakra.Backend PRIVATE -fdelayed-template-parsing)

--- a/chakracore-cxx/lib/Common/Common/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Common/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(Chakra.Common.Common PUBLIC
 
 target_compile_options(Chakra.Common.Common PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Common.Common PUBLIC CommonCommonPch.h)

--- a/chakracore-cxx/lib/Common/Common/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Common/CMakeLists.txt
@@ -33,4 +33,6 @@ target_compile_definitions(Chakra.Common.Common PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Common.Common PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Common.Common PUBLIC CommonCommonPch.h)

--- a/chakracore-cxx/lib/Common/Common/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Common/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(Chakra.Common.Common PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Common.Common PUBLIC CommonCommonPch.h)

--- a/chakracore-cxx/lib/Common/Common/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Common/CMakeLists.txt
@@ -33,6 +33,8 @@ target_compile_definitions(Chakra.Common.Common PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Common.Common PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Common.Common PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Common.Common PUBLIC CommonCommonPch.h)

--- a/chakracore-cxx/lib/Common/Common/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Common/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_definitions(Chakra.Common.Common PUBLIC
 target_compile_options(Chakra.Common.Common PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Common.Common PUBLIC CommonCommonPch.h)

--- a/chakracore-cxx/lib/Common/Core/Assertions.h
+++ b/chakracore-cxx/lib/Common/Core/Assertions.h
@@ -73,7 +73,7 @@ extern thread_local int IsInAssert;
 #define AnalysisAssertOrFailFastMsg(x, msg) AssertOrFailFast(x)
 #endif
 
-#define Unused(var) var;
+#define Unused(var)
 
 #define UNREACHED   (0)
 

--- a/chakracore-cxx/lib/Common/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Core/CMakeLists.txt
@@ -30,4 +30,6 @@ target_compile_definitions(Chakra.Common.Core PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Common.Core PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Common.Core PUBLIC CommonCorePch.h)

--- a/chakracore-cxx/lib/Common/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Core/CMakeLists.txt
@@ -30,6 +30,8 @@ target_compile_definitions(Chakra.Common.Core PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Common.Core PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Common.Core PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Common.Core PUBLIC CommonCorePch.h)

--- a/chakracore-cxx/lib/Common/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Core/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_definitions(Chakra.Common.Core PUBLIC
 target_compile_options(Chakra.Common.Core PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Common.Core PUBLIC CommonCorePch.h)

--- a/chakracore-cxx/lib/Common/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Core/CMakeLists.txt
@@ -32,6 +32,7 @@ target_compile_definitions(Chakra.Common.Core PUBLIC
 
 target_compile_options(Chakra.Common.Core PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Common.Core PUBLIC CommonCorePch.h)

--- a/chakracore-cxx/lib/Common/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Core/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_options(Chakra.Common.Core PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Common.Core PUBLIC CommonCorePch.h)

--- a/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
@@ -27,6 +27,7 @@ target_compile_definitions(Chakra.Common.DataStructures PUBLIC
 
 target_compile_options(Chakra.Common.DataStructures PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Common.DataStructures PUBLIC CommonDataStructuresPch.h)

--- a/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
@@ -25,6 +25,8 @@ target_compile_definitions(Chakra.Common.DataStructures PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Common.DataStructures PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Common.DataStructures PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Common.DataStructures PUBLIC CommonDataStructuresPch.h)

--- a/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/DataStructures/CMakeLists.txt
@@ -25,4 +25,6 @@ target_compile_definitions(Chakra.Common.DataStructures PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Common.DataStructures PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Common.DataStructures PUBLIC CommonDataStructuresPch.h)

--- a/chakracore-cxx/lib/Common/Exceptions/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Exceptions/CMakeLists.txt
@@ -18,4 +18,6 @@ target_compile_definitions(Chakra.Common.Exceptions PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Common.Exceptions PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Common.Exceptions PUBLIC CommonExceptionsPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -70,6 +70,7 @@ target_compile_definitions(Chakra.Common.Memory PUBLIC
 
 target_compile_options(Chakra.Common.Memory PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -73,6 +73,7 @@ target_compile_options(Chakra.Common.Memory PRIVATE
     -Wno-unused-value
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -68,6 +68,8 @@ target_compile_definitions(Chakra.Common.Memory PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Common.Memory PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Common.Memory PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -71,6 +71,7 @@ target_compile_definitions(Chakra.Common.Memory PUBLIC
 target_compile_options(Chakra.Common.Memory PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -68,4 +68,6 @@ target_compile_definitions(Chakra.Common.Memory PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Common.Memory PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
+++ b/chakracore-cxx/lib/Common/Memory/CMakeLists.txt
@@ -72,6 +72,7 @@ target_compile_options(Chakra.Common.Memory PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Common.Memory PUBLIC CommonMemoryPch.h)

--- a/chakracore-cxx/lib/Jsrt/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/CMakeLists.txt
@@ -44,6 +44,7 @@ target_compile_options(Chakra.Jsrt PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Jsrt PUBLIC JsrtPch.h)

--- a/chakracore-cxx/lib/Jsrt/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/CMakeLists.txt
@@ -40,4 +40,6 @@ target_compile_definitions(Chakra.Jsrt PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Jsrt PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Jsrt PUBLIC JsrtPch.h)

--- a/chakracore-cxx/lib/Jsrt/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/CMakeLists.txt
@@ -42,6 +42,7 @@ target_compile_definitions(Chakra.Jsrt PUBLIC
 
 target_compile_options(Chakra.Jsrt PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Jsrt PUBLIC JsrtPch.h)

--- a/chakracore-cxx/lib/Jsrt/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/CMakeLists.txt
@@ -43,6 +43,7 @@ target_compile_definitions(Chakra.Jsrt PUBLIC
 target_compile_options(Chakra.Jsrt PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Jsrt PUBLIC JsrtPch.h)

--- a/chakracore-cxx/lib/Jsrt/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/CMakeLists.txt
@@ -40,6 +40,8 @@ target_compile_definitions(Chakra.Jsrt PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Jsrt PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Jsrt PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Jsrt PUBLIC JsrtPch.h)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -30,4 +30,5 @@ target_compile_options(Chakra.Jsrt.Core PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -25,3 +25,5 @@ target_include_directories (Chakra.Jsrt.Core PUBLIC
 target_compile_definitions(Chakra.Jsrt.Core PUBLIC
     PAL_STDCPP_COMPAT
 )
+
+target_compile_options(Chakra.Jsrt.Core PRIVATE -fdelayed-template-parsing)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -28,4 +28,5 @@ target_compile_definitions(Chakra.Jsrt.Core PUBLIC
 
 target_compile_options(Chakra.Jsrt.Core PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-unused-but-set-variable)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -31,4 +31,5 @@ target_compile_options(Chakra.Jsrt.Core PRIVATE
     -Wno-unused-value
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -29,4 +29,5 @@ target_compile_definitions(Chakra.Jsrt.Core PUBLIC
 target_compile_options(Chakra.Jsrt.Core PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -26,4 +26,6 @@ target_compile_definitions(Chakra.Jsrt.Core PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Jsrt.Core PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Jsrt.Core PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)

--- a/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
+++ b/chakracore-cxx/lib/Jsrt/Core/CMakeLists.txt
@@ -32,4 +32,5 @@ target_compile_options(Chakra.Jsrt.Core PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -54,6 +54,7 @@ target_compile_options(Chakra.Parser PRIVATE
     -Wno-unused-value
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -49,4 +49,6 @@ target_compile_definitions(Chakra.Parser PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Parser PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -53,6 +53,7 @@ target_compile_options(Chakra.Parser PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_definitions(Chakra.Parser PUBLIC
 
 target_compile_options(Chakra.Parser PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -52,6 +52,7 @@ target_compile_definitions(Chakra.Parser PUBLIC
 target_compile_options(Chakra.Parser PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Parser/CMakeLists.txt
+++ b/chakracore-cxx/lib/Parser/CMakeLists.txt
@@ -49,6 +49,8 @@ target_compile_definitions(Chakra.Parser PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Parser PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Parser PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(Chakra.Parser PUBLIC ParserPch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -60,6 +60,7 @@ target_compile_options(Chakra.Runtime.Base PRIVATE
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -58,6 +58,7 @@ target_compile_definitions(Chakra.Runtime.Base PUBLIC
 target_compile_options(Chakra.Runtime.Base PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -59,6 +59,7 @@ target_compile_options(Chakra.Runtime.Base PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -55,6 +55,8 @@ target_compile_definitions(Chakra.Runtime.Base PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.Base PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.Base PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -61,6 +61,7 @@ target_compile_options(Chakra.Runtime.Base PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -57,6 +57,7 @@ target_compile_definitions(Chakra.Runtime.Base PUBLIC
 
 target_compile_options(Chakra.Runtime.Base PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Base/CMakeLists.txt
@@ -55,4 +55,6 @@ target_compile_definitions(Chakra.Runtime.Base PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Base PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Base PUBLIC RuntimeBasePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -46,6 +46,7 @@ target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -Wno-unused-value
     -Wno-tautological-overlap-compare
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -47,6 +47,7 @@ target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -Wno-tautological-overlap-compare
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -45,6 +45,7 @@ target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-tautological-overlap-compare
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -41,4 +41,6 @@ target_compile_definitions(Chakra.Runtime.ByteCode PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.ByteCode PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -48,6 +48,7 @@ target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
     -Wno-unused-variable
-    -Wno-reorder-ctor)
+    -Wno-reorder-ctor
+    -Wno-enum-compare-switch)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -43,6 +43,7 @@ target_compile_definitions(Chakra.Runtime.ByteCode PUBLIC
 
 target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-tautological-overlap-compare)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -44,6 +44,7 @@ target_compile_definitions(Chakra.Runtime.ByteCode PUBLIC
 target_compile_options(Chakra.Runtime.ByteCode PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-tautological-overlap-compare)
+    -Wno-tautological-overlap-compare
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/ByteCode/CMakeLists.txt
@@ -41,6 +41,8 @@ target_compile_definitions(Chakra.Runtime.ByteCode PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.ByteCode PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.ByteCode PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(Chakra.Runtime.ByteCode PUBLIC RuntimeByteCodePch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -46,4 +46,6 @@ target_compile_definitions(Chakra.Runtime.Debug PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Debug PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -48,6 +48,7 @@ target_compile_definitions(Chakra.Runtime.Debug PUBLIC
 
 target_compile_options(Chakra.Runtime.Debug PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -46,6 +46,8 @@ target_compile_definitions(Chakra.Runtime.Debug PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.Debug PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.Debug PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -49,6 +49,7 @@ target_compile_definitions(Chakra.Runtime.Debug PUBLIC
 target_compile_options(Chakra.Runtime.Debug PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_options(Chakra.Runtime.Debug PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Debug/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_options(Chakra.Runtime.Debug PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.Debug PUBLIC RuntimeDebugPch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -104,4 +104,6 @@ target_compile_definitions(Chakra.Runtime.Language PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Language PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -106,6 +106,7 @@ target_compile_definitions(Chakra.Runtime.Language PUBLIC
 
 target_compile_options(Chakra.Runtime.Language PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-sometimes-uninitialized)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -109,6 +109,7 @@ target_compile_options(Chakra.Runtime.Language PRIVATE
     -Wno-unused-value
     -Wno-sometimes-uninitialized
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -111,6 +111,7 @@ target_compile_options(Chakra.Runtime.Language PRIVATE
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -108,6 +108,7 @@ target_compile_options(Chakra.Runtime.Language PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-sometimes-uninitialized
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -110,6 +110,7 @@ target_compile_options(Chakra.Runtime.Language PRIVATE
     -Wno-sometimes-uninitialized
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -104,6 +104,8 @@ target_compile_definitions(Chakra.Runtime.Language PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.Language PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.Language PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -107,6 +107,7 @@ target_compile_definitions(Chakra.Runtime.Language PUBLIC
 target_compile_options(Chakra.Runtime.Language PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-sometimes-uninitialized)
+    -Wno-sometimes-uninitialized
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Language/CMakeLists.txt
@@ -112,6 +112,7 @@ target_compile_options(Chakra.Runtime.Language PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.Language PUBLIC RuntimeLanguagePch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -158,4 +158,6 @@ target_compile_definitions(Chakra.Runtime.Library PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Library PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -166,6 +166,7 @@ target_compile_options(Chakra.Runtime.Library PRIVATE
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -161,6 +161,7 @@ target_compile_definitions(Chakra.Runtime.Library PUBLIC
 target_compile_options(Chakra.Runtime.Library PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
-    -Wno-sometimes-uninitialized)
+    -Wno-sometimes-uninitialized
+    -Wno-unused-lambda-capture)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -163,6 +163,7 @@ target_compile_options(Chakra.Runtime.Library PRIVATE
     -Wno-unused-value
     -Wno-sometimes-uninitialized
     -Wno-unused-lambda-capture
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -165,6 +165,7 @@ target_compile_options(Chakra.Runtime.Library PRIVATE
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
     -Wno-unused-private-field
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -162,6 +162,7 @@ target_compile_options(Chakra.Runtime.Library PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-value
     -Wno-sometimes-uninitialized
-    -Wno-unused-lambda-capture)
+    -Wno-unused-lambda-capture
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -158,6 +158,8 @@ target_compile_definitions(Chakra.Runtime.Library PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.Library PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.Library PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-value)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -164,6 +164,7 @@ target_compile_options(Chakra.Runtime.Library PRIVATE
     -Wno-sometimes-uninitialized
     -Wno-unused-lambda-capture
     -Wno-unused-but-set-variable
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Library/CMakeLists.txt
@@ -160,6 +160,7 @@ target_compile_definitions(Chakra.Runtime.Library PUBLIC
 
 target_compile_options(Chakra.Runtime.Library PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-value)
+    -Wno-unused-value
+    -Wno-sometimes-uninitialized)
 
 target_precompile_headers(Chakra.Runtime.Library PUBLIC RuntimeLibraryPch.h)

--- a/chakracore-cxx/lib/Runtime/Math/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Math/CMakeLists.txt
@@ -23,4 +23,6 @@ target_compile_definitions(Chakra.Runtime.Math PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Math PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Math PUBLIC RuntimeMathPch.h)

--- a/chakracore-cxx/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -50,3 +50,6 @@ target_include_directories (Chakra.Runtime.PlatformAgnostic PUBLIC
 target_compile_definitions(Chakra.Runtime.PlatformAgnostic PUBLIC
     PAL_STDCPP_COMPAT
 )
+
+target_compile_options(Chakra.Runtime.PlatformAgnostic PRIVATE
+    -Wno-unused-private-field)

--- a/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
@@ -48,6 +48,8 @@ target_compile_definitions(Chakra.Runtime.Types PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.Runtime.Types PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.Runtime.Types PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.Runtime.Types PUBLIC RuntimeTypePch.h)

--- a/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
@@ -52,6 +52,7 @@ target_compile_options(Chakra.Runtime.Types PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
     -Wno-overloaded-virtual
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.Runtime.Types PUBLIC RuntimeTypePch.h)

--- a/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
@@ -48,4 +48,6 @@ target_compile_definitions(Chakra.Runtime.Types PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.Runtime.Types PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.Runtime.Types PUBLIC RuntimeTypePch.h)

--- a/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_definitions(Chakra.Runtime.Types PUBLIC
 
 target_compile_options(Chakra.Runtime.Types PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-overloaded-virtual)
 
 target_precompile_headers(Chakra.Runtime.Types PUBLIC RuntimeTypePch.h)

--- a/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
+++ b/chakracore-cxx/lib/Runtime/Types/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_definitions(Chakra.Runtime.Types PUBLIC
 target_compile_options(Chakra.Runtime.Types PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-but-set-variable
-    -Wno-overloaded-virtual)
+    -Wno-overloaded-virtual
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.Runtime.Types PUBLIC RuntimeTypePch.h)

--- a/chakracore-cxx/lib/SCACore/CMakeLists.txt
+++ b/chakracore-cxx/lib/SCACore/CMakeLists.txt
@@ -31,4 +31,6 @@ target_compile_definitions(Chakra.SCACore PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.SCACore PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.SCACore PUBLIC SCACorePch.h)

--- a/chakracore-cxx/lib/SCACore/CMakeLists.txt
+++ b/chakracore-cxx/lib/SCACore/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_definitions(Chakra.SCACore PUBLIC
 
 target_compile_options(Chakra.SCACore PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-but-set-variable)
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.SCACore PUBLIC SCACorePch.h)

--- a/chakracore-cxx/lib/SCACore/CMakeLists.txt
+++ b/chakracore-cxx/lib/SCACore/CMakeLists.txt
@@ -31,6 +31,8 @@ target_compile_definitions(Chakra.SCACore PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.SCACore PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.SCACore PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-but-set-variable)
 
 target_precompile_headers(Chakra.SCACore PUBLIC SCACorePch.h)

--- a/chakracore-cxx/lib/WasmReader/CMakeLists.txt
+++ b/chakracore-cxx/lib/WasmReader/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(Chakra.WasmReader PUBLIC
 target_compile_options(Chakra.WasmReader PRIVATE
     -fdelayed-template-parsing
     -Wno-unused-private-field
-    -Wno-unused-variable)
+    -Wno-unused-variable
+    -Wno-reorder-ctor)
 
 target_precompile_headers(Chakra.WasmReader PUBLIC WasmReaderPch.h)

--- a/chakracore-cxx/lib/WasmReader/CMakeLists.txt
+++ b/chakracore-cxx/lib/WasmReader/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(Chakra.WasmReader PUBLIC
 
 target_compile_options(Chakra.WasmReader PRIVATE
     -fdelayed-template-parsing
-    -Wno-unused-private-field)
+    -Wno-unused-private-field
+    -Wno-unused-variable)
 
 target_precompile_headers(Chakra.WasmReader PUBLIC WasmReaderPch.h)

--- a/chakracore-cxx/lib/WasmReader/CMakeLists.txt
+++ b/chakracore-cxx/lib/WasmReader/CMakeLists.txt
@@ -32,4 +32,6 @@ target_compile_definitions(Chakra.WasmReader PUBLIC
     PAL_STDCPP_COMPAT
 )
 
+target_compile_options(Chakra.WasmReader PRIVATE -fdelayed-template-parsing)
+
 target_precompile_headers(Chakra.WasmReader PUBLIC WasmReaderPch.h)

--- a/chakracore-cxx/lib/WasmReader/CMakeLists.txt
+++ b/chakracore-cxx/lib/WasmReader/CMakeLists.txt
@@ -32,6 +32,8 @@ target_compile_definitions(Chakra.WasmReader PUBLIC
     PAL_STDCPP_COMPAT
 )
 
-target_compile_options(Chakra.WasmReader PRIVATE -fdelayed-template-parsing)
+target_compile_options(Chakra.WasmReader PRIVATE
+    -fdelayed-template-parsing
+    -Wno-unused-private-field)
 
 target_precompile_headers(Chakra.WasmReader PUBLIC WasmReaderPch.h)

--- a/chakracore-cxx/pal/src/CMakeLists.txt
+++ b/chakracore-cxx/pal/src/CMakeLists.txt
@@ -136,7 +136,6 @@ add_library(Chakra.Pal
 target_compile_options(Chakra.Pal PRIVATE -Wall
     # -Werror
     -Wno-format
-    -Wno-vla-cxx-extension
 )
 
 target_include_directories(Chakra.Pal


### PR DESCRIPTION
- **add more aliases**
- **move `-fdelayed-template-parsing`**
- **move `-Wno-unused-value`**
- **move `-Wno-sometimes-uninitialized`**
- **move `-Wno-tautological-overlap-compare`**
- **move `-Wno-unused-lambda-capture`**
- **move `-Wno-unused-but-set-variable`**
- **move `-Wno-unused-private-field`**
- **move `-Wno-overloaded-virtual`**
- **move `-Wno-unused-variable`**
- **move `-Wno-reorder-ctor`**
- **remove `-Wno-nontrivial-memcall`**
- **remove `-Wno-unknown-warning-option`**
- **move `-Wno-enum-compare-switch`**
