### PR TITLE
introduce `tracing` for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,4 @@ project(chakra_rs)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(chakracore-cxx)
-install(TARGETS chhelper ChakraCoreStatic)
+install(TARGETS chhelper ChakraCoreStatic Chakra.Ffi)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,8 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -281,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,10 +304,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -358,9 +396,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -370,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -381,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -485,6 +523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +542,12 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -534,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +626,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +697,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "cxx",
  "cxx-build",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "chakracore-sys",
  "pretty_assertions",
  "rstest",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
@@ -670,6 +671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,12 +690,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -255,6 +255,8 @@ endif ()
 # detect features
 include_directories(SYSTEM /usr/local/include)
 
+add_subdirectory(ffi)
+
 add_subdirectory(pal)
 
 add_subdirectory(lib)

--- a/chakracore-cxx/CMakeLists.txt
+++ b/chakracore-cxx/CMakeLists.txt
@@ -246,6 +246,7 @@ if (CC_TARGETS_ARM64)
 endif ()
 
 include_directories(${CMAKE_SOURCE_DIR}/target/cxxbridge)
+include_directories(ffi/include)
 include_directories(SYSTEM ${ICU_INCLUDE_PATH})
 
 if (IN_DOCKER)

--- a/chakracore-cxx/bin/ch/ChakraRtInterface.h
+++ b/chakracore-cxx/bin/ch/ChakraRtInterface.h
@@ -118,7 +118,6 @@ public:
     static JsErrorCode WINAPI JsDiagGetSource(unsigned int scriptId, JsValueRef *source) { return chakracore::jsrt::JsDiagGetSource(scriptId, source); }
     static JsErrorCode WINAPI JsDiagSetBreakpoint(unsigned int scriptId, unsigned int lineNumber, unsigned int columnNumber, JsValueRef *breakpoint) { return chakracore::jsrt::JsDiagSetBreakpoint(scriptId, lineNumber, columnNumber, breakpoint); }
     static JsErrorCode WINAPI JsDiagGetStackTrace(JsValueRef *stackTrace) { return chakracore::jsrt::JsDiagGetStackTrace(stackTrace); }
-    static JsErrorCode WINAPI JsDiagRequestAsyncBreak(JsRuntimeHandle runtimeHandle) { return chakracore::jsrt::JsDiagRequestAsyncBreak(runtimeHandle); }
     static JsErrorCode WINAPI JsDiagGetBreakpoints(JsValueRef * breakpoints) { return chakracore::jsrt::JsDiagGetBreakpoints(breakpoints); }
     static JsErrorCode WINAPI JsDiagRemoveBreakpoint(unsigned int breakpointId) { return chakracore::jsrt::JsDiagRemoveBreakpoint(breakpointId); }
     static JsErrorCode WINAPI JsDiagSetBreakOnException(JsRuntimeHandle runtimeHandle, JsDiagBreakOnExceptionAttributes exceptionAttributes) { return chakracore::jsrt::JsDiagSetBreakOnException(runtimeHandle, exceptionAttributes); }

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -233,17 +233,6 @@ const char* Helpers::JsErrorCodeToString(JsErrorCode jsErrorCode)
     }
 }
 
-void Helpers::LogError(__nullterminated const char16_t *msg, ...)
-{
-    va_list args;
-    va_start(args, msg);
-    std::print("ERROR: ");
-    PAL_vfwprintf(stderr, msg, args);
-    std::println();
-    fflush(stdout);
-    va_end(args);
-}
-
 int32_t Helpers::LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError)
 {
     int32_t hr = S_OK;

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -260,8 +260,7 @@ int32_t Helpers::LoadBinaryFile(const char * filename, const char *& contents, u
     {
         if (printFileOpenError)
         {
-            fprintf(stderr, "Error in opening file '%s' ", filename);
-            fprintf(stderr, "\n");
+            chakra::Logger::error(std::format("Error in opening file '{}'", filename));
         }
         return E_FAIL;
     }

--- a/chakracore-cxx/bin/ch/Helpers.cpp
+++ b/chakracore-cxx/bin/ch/Helpers.cpp
@@ -8,6 +8,8 @@
 #include <print>
 #include <sys/stat.h>
 
+#include "chakra/Logger.h"
+
 namespace fs = std::filesystem;
 
 int32_t Helpers::LoadScriptFromFile(const char * filenameToLoad, const char *& contents, uint32_t* lengthBytesOut /*= nullptr*/, const std::optional<std::filesystem::path> &fullPath, bool shouldMute /*=false */)
@@ -74,7 +76,7 @@ int32_t Helpers::LoadScriptFromFile(const char * filenameToLoad, const char *& c
 
     if (nullptr == pRawBytes)
     {
-        std::print(stderr, "out of memory");
+        chakra::Logger::error("out of memory");
         IfFailGo(E_OUTOFMEMORY);
     }
 
@@ -132,7 +134,7 @@ int32_t Helpers::LoadScriptFromFile(const char * filenameToLoad, const char *& c
 
             {
                 // unicode unsupported
-                std::print(stderr, "unsupported file encoding. Only ANSI and UTF8 supported");
+                chakra::Logger::error("unsupported file encoding. Only ANSI and UTF8 supported");
                 IfFailGo(E_UNEXPECTED);
             }
 #pragma prefast(pop)
@@ -278,7 +280,7 @@ int32_t Helpers::LoadBinaryFile(const char * filename, const char *& contents, u
     }
     else
     {
-        std::print(stderr, "out of memory");
+        chakra::Logger::error("out of memory");
         IfFailGo(E_OUTOFMEMORY);
     }
     //
@@ -287,7 +289,7 @@ int32_t Helpers::LoadBinaryFile(const char * filename, const char *& contents, u
     result = std::fread((void*)contents, sizeof(char), lengthBytes, file);
     if (result != lengthBytes)
     {
-        std::print(stderr, "Read error");
+        chakra::Logger::error("Read error");
         IfFailGo(E_FAIL);
     }
 

--- a/chakracore-cxx/bin/ch/Helpers.h
+++ b/chakracore-cxx/bin/ch/Helpers.h
@@ -11,6 +11,5 @@ class Helpers
 public :
     static int32_t LoadScriptFromFile(const char * filename, const char *& contents, uint32_t* lengthBytesOut = nullptr, const std::optional<std::filesystem::path> &fullPath = std::nullopt, bool shouldMute = false);
     static const char* JsErrorCodeToString(JsErrorCode jsErrorCode);
-    static void LogError(__nullterminated const char16_t *msg, ...);
     static int32_t LoadBinaryFile(const char * filename, const char *& contents, uint32_t& lengthBytes, bool printFileOpenError = true);
 };

--- a/chakracore-cxx/bin/ch/WScriptJsrt.cpp
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.cpp
@@ -958,15 +958,6 @@ JsValueRef WScriptJsrt::DumpFunctionPositionCallback(JsValueRef callee, bool isC
     return JS_INVALID_REFERENCE;
 }
 
-// TODO (hanhossain): remove this method entirely
-JsValueRef WScriptJsrt::RequestAsyncBreakCallback(JsValueRef callee, bool isConstructCall,
-    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
-{
-    Helpers::LogError(u"RequestAsyncBreak can only be called when debugger is attached");
-
-    return JS_INVALID_REFERENCE;
-}
-
 bool WScriptJsrt::CreateNamedFunction(const char* nameString, JsNativeFunction callback,
     JsValueRef* functionVar)
 {
@@ -1017,7 +1008,6 @@ bool WScriptJsrt::Initialize()
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Attach", AttachCallback));
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Detach", DetachCallback));
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "DumpFunctionPosition", DumpFunctionPositionCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "RequestAsyncBreak", RequestAsyncBreakCallback));
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadBinaryFile", LoadBinaryFileCallback));
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadTextFile", LoadTextFileCallback));
     IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Flag", FlagCallback));

--- a/chakracore-cxx/bin/ch/WScriptJsrt.cpp
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.cpp
@@ -1709,7 +1709,7 @@ bool WScriptJsrt::PrintException(const char * fileName, JsErrorCode jsErrorCode,
 
             if (errorMessage.Initialize(exception) != JsNoError)
             {
-                std::println(stderr, "ERROR attempting to coerce error to string, using alternate handler");
+                std::println("ERROR attempting to coerce error to string, using alternate handler");
                 bool hasException = false;
                 ChakraRTInterface::JsHasException(&hasException);
                 if (hasException)
@@ -1743,12 +1743,12 @@ bool WScriptJsrt::PrintException(const char * fileName, JsErrorCode jsErrorCode,
                         IfJsrtErrorFail(CreatePropertyIdFromString("column", &columnPropertyId), false);
                         IfJsrtErrorFail(ChakraRTInterface::JsGetProperty(metaData, columnPropertyId, &columnProperty), false);
                         IfJsrtErrorFail(ChakraRTInterface::JsNumberToInt(columnProperty, &column), false);
-                        std::println(stderr, "{}\n        at code ({}:{}:{})",
+                        std::println("{}\n        at code ({}:{}:{})",
                             errorMessage.GetString(), path.filename().string(), line + 1, column + 1);
                     }
                     else
                     {
-                        std::println(stderr, "{}\n\tat code ({}:\?\?:\?\?)", errorMessage.GetString(), path.filename().string());
+                        std::println("{}\n\tat code ({}:\?\?:\?\?)", errorMessage.GetString(), path.filename().string());
                     }
                     return true;
                 }
@@ -1773,7 +1773,7 @@ bool WScriptJsrt::PrintException(const char * fileName, JsErrorCode jsErrorCode,
                 IfJsrtErrorFail(ChakraRTInterface::JsGetProperty(exception, columnPropertyId, &columnProperty), false);
                 IfJsrtErrorFail(ChakraRTInterface::JsNumberToInt(columnProperty, &column), false);
 
-                std::println(stderr, "{}\n\tat code ({}:{}:{})",
+                std::println("{}\n\tat code ({}:{}:{})",
                     errorMessage.GetString(), path.filename().string(), (int)line + 1,
                     (int)column + 1);
             }
@@ -1802,13 +1802,13 @@ bool WScriptJsrt::PrintException(const char * fileName, JsErrorCode jsErrorCode,
                     std::filesystem::path filepath(fName);
 
                     // do not mix char/wchar. print them separately
-                    std::println(stderr, "thrown at {}:\n^", filepath.filename().string());
-                    std::println(stderr, "{}", errorMessage.GetString());
+                    std::println("thrown at {}:\n^", filepath.filename().string());
+                    std::println("{}", errorMessage.GetString());
                 }
                 else
                 {
                     IfJsrtErrorFail(errorStack.Initialize(stackProperty), false);
-                    std::println(stderr, "{}", errorStack.GetString());
+                    std::println("{}", errorStack.GetString());
                 }
             }
         }

--- a/chakracore-cxx/bin/ch/WScriptJsrt.cpp
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.cpp
@@ -14,6 +14,8 @@
 #include <filesystem>
 #include <iostream>
 
+#include "chakra/Logger.h"
+
 namespace fs = std::filesystem;
 
 #if defined(_AMD64_) || defined(_IA64_) || defined(_M_AMD64) || defined(_M_IA64)
@@ -1417,7 +1419,7 @@ JsValueRef WScriptJsrt::LoadBinaryFileCallback(JsValueRef callee,
             IfJsrtErrorSetGoLabel(ChakraRTInterface::JsGetArrayBufferStorage(arrayBuffer, &buffer, &bufferLength), ErrorStillFree);
             if (bufferLength < lengthBytes)
             {
-                std::println(stderr, "Array buffer size is insufficient to store the binary file.");
+                chakra::Logger::error("Array buffer size is insufficient to store the binary file.");
             }
             else
             {

--- a/chakracore-cxx/bin/ch/WScriptJsrt.cpp
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.cpp
@@ -215,7 +215,7 @@ JsValueRef WScriptJsrt::LoadScriptFileHelper(JsValueRef callee, JsValueRef *argu
             hr = Helpers::LoadScriptFromFile(*fileName, fileContent);
             if (FAILED(hr))
             {
-                fprintf(stderr, "Couldn't load file '%s'\n", fileName.GetString());
+                chakra::Logger::error(std::format("Couldn't load file '{}'", fileName.GetString()));
                 IfJsrtErrorSetGo(ChakraRTInterface::JsGetUndefinedValue(&returnValue));
                 return returnValue;
             }
@@ -1245,7 +1245,7 @@ JsValueRef WScriptJsrt::LoadTextFileCallback(JsValueRef callee, bool isConstruct
 
             if (FAILED(hr))
             {
-                fprintf(stderr, "Couldn't load file '%s'\n", fileName.GetString());
+                chakra::Logger::error(std::format("Couldn't load file '{}'", fileName.GetString()));
                 IfJsrtErrorSetGo(ChakraRTInterface::JsGetUndefinedValue(&returnValue));
                 return returnValue;
             }
@@ -1407,7 +1407,7 @@ JsValueRef WScriptJsrt::LoadBinaryFileCallback(JsValueRef callee,
 
             if (FAILED(hr))
             {
-                fprintf(stderr, "Couldn't load file '%s'\n", fileName.GetString());
+                chakra::Logger::error(std::format("Couldn't load file '{}'", fileName.GetString()));
                 IfJsrtErrorSetGoLabel(ChakraRTInterface::JsGetUndefinedValue(&returnValue), Error);
                 return returnValue;
             }
@@ -1814,13 +1814,13 @@ bool WScriptJsrt::PrintException(const char * fileName, JsErrorCode jsErrorCode,
         }
         else
         {
-            std::println(stderr, "Error : %{}", errorTypeString);
+            chakra::Logger::error(std::format("Error : {}", errorTypeString));
         }
         return true;
     }
     else
     {
-        std::println(stderr, "Error : %{}", errorTypeString);
+        chakra::Logger::error(std::format("Error : {}", errorTypeString));
     }
     return false;
 }
@@ -1955,7 +1955,7 @@ int32_t WScriptJsrt::ModuleMessage::Call(const char * fileName)
                     auto actualModuleRecord = moduleRecordMap.find(fullPath_.value());
                     if (actualModuleRecord == moduleRecordMap.end() || moduleErrMap[actualModuleRecord->second] == RootModule)
                     {
-                        fprintf(stderr, "Couldn't load file '%s'\n", specifierStr.GetString());
+                        chakra::Logger::error(std::format("Couldn't load file '{}'", specifierStr.GetString()));
                     }
                 }
                 LoadScript(nullptr, !fullPath_ ? *specifierStr : fullPath_->c_str(), nullptr, "module", true, WScriptJsrt::FinalizeFree, false);

--- a/chakracore-cxx/bin/ch/WScriptJsrt.h
+++ b/chakracore-cxx/bin/ch/WScriptJsrt.h
@@ -125,7 +125,6 @@ private:
     static JsValueRef CALLBACK AttachCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef CALLBACK DetachCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef CALLBACK DumpFunctionPositionCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
-    static JsValueRef CALLBACK RequestAsyncBreakCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
 
     static JsErrorCode CALLBACK LoadModuleFromString(const char * fileName, const char * fileContent, const char * fullName = nullptr, bool isFile = false);
 

--- a/chakracore-cxx/bin/ch/stdafx.h
+++ b/chakracore-cxx/bin/ch/stdafx.h
@@ -32,6 +32,8 @@
 #include "PlatformAgnostic/CommonPal.h"
 
 #include <stdarg.h>
+#include <format>
+#include "chakra/Logger.h"
 
 #if defined(_DEBUG)
 #define _DEBUG_WAS_DEFINED
@@ -62,7 +64,7 @@
 do { \
 if (!(exp)) \
 { \
-    fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
+    chakra::Logger::error(std::format("ASSERTION ({}, line {}) {} {}", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment)); \
     DebugBreak(); \
 } \
 } while (0)
@@ -92,7 +94,7 @@ using utf8::WideStringToNarrowDynamic;
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         goto Error; \
     } \
 } while (0)
@@ -102,7 +104,7 @@ do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         hr = E_FAIL; \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         goto Error; \
     } \
 } while (0)
@@ -111,7 +113,7 @@ do { \
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         goto label; \
     } \
 } while (0)
@@ -120,7 +122,7 @@ do { \
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         return JS_INVALID_REFERENCE; \
     } \
 } while (0)
@@ -129,7 +131,7 @@ do { \
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         return false; \
     } \
 } while (0)
@@ -138,7 +140,7 @@ do { \
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
-        std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
+        chakra::Logger::error(std::format("ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode))); \
         return (jsErrorCode); \
     } \
 } while (0)

--- a/chakracore-cxx/bin/ch/stdafx.h
+++ b/chakracore-cxx/bin/ch/stdafx.h
@@ -63,7 +63,6 @@ do { \
 if (!(exp)) \
 { \
     fprintf(stderr, "ASSERTION (%s, line %d) %s %s\n", __FILE__, __LINE__, CHAKRACORE_STRINGIZE(exp), comment); \
-    fflush(stderr); \
     DebugBreak(); \
 } \
 } while (0)
@@ -89,13 +88,11 @@ using utf8::WideStringToNarrowDynamic;
 #include "PlatformAgnostic/ChakraICU.h"
 #endif
 
-// TODO (hanhossain): do we still need this to fflush(stderr)?
 #define IfJsErrorFailLog(expr) \
 do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         goto Error; \
     } \
 } while (0)
@@ -106,7 +103,6 @@ do { \
     if ((jsErrorCode) != JsNoError) { \
         hr = E_FAIL; \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         goto Error; \
     } \
 } while (0)
@@ -116,7 +112,6 @@ do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         goto label; \
     } \
 } while (0)
@@ -126,7 +121,6 @@ do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         return JS_INVALID_REFERENCE; \
     } \
 } while (0)
@@ -136,7 +130,6 @@ do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         return false; \
     } \
 } while (0)
@@ -146,7 +139,6 @@ do { \
     JsErrorCode jsErrorCode = expr; \
     if ((jsErrorCode) != JsNoError) { \
         std::println(stderr, "ERROR: {} failed. JsErrorCode=0x{:x} ({})", #expr, static_cast<int>(jsErrorCode), Helpers::JsErrorCodeToString(jsErrorCode)); \
-        fflush(stderr); \
         return (jsErrorCode); \
     } \
 } while (0)

--- a/chakracore-cxx/ffi/CMakeLists.txt
+++ b/chakracore-cxx/ffi/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(Chakra.Ffi Logger.cpp)
+
+target_include_directories(Chakra.Ffi PUBLIC include)

--- a/chakracore-cxx/ffi/Logger.cpp
+++ b/chakracore-cxx/ffi/Logger.cpp
@@ -1,0 +1,10 @@
+#include "chakra/Logger.h"
+#include "chakracore-sys/src/logger.rs.h"
+
+namespace chakra
+{
+    void Logger::error(const std::string &message, const std::source_location &location)
+    {
+        chakra_rs::log::error(location.function_name(), location.file_name(), location.line(), message);
+    }
+} // namespace chakra

--- a/chakracore-cxx/ffi/include/chakra/Logger.h
+++ b/chakracore-cxx/ffi/include/chakra/Logger.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <source_location>
+#include <string>
+
+namespace chakra
+{
+
+    class Logger
+    {
+    public:
+        static void error(const std::string &message,
+                          const std::source_location &location = std::source_location::current());
+    };
+
+} // namespace chakra

--- a/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
+++ b/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
@@ -136,7 +136,6 @@ namespace Js {
         if (AssertsToConsole)
         {
             fprintf(stderr, "ASSERTION %u: (%s, line %u) %s\n Failure: %s\n", getpid(), fileName, lineNumber, message, error);
-            fflush(stderr);
             return false;
         }
 

--- a/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
+++ b/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
@@ -14,6 +14,8 @@
 // Header files required before including ConfigFlagsTable.h
 
 #include <unistd.h>
+#include <format>
+#include "chakra/Logger.h"
 
 #include "Interface/EnumHelp.h"
 #include "Common/MathUtil.h"
@@ -135,7 +137,7 @@ namespace Js {
     {
         if (AssertsToConsole)
         {
-            fprintf(stderr, "ASSERTION %u: (%s, line %u) %s\n Failure: %s\n", getpid(), fileName, lineNumber, message, error);
+            chakra::Logger::error(std::format("ASSERTION {}: ({}, line {}) {}\n Failure: {}\n", getpid(), fileName, lineNumber, message, error));
             return false;
         }
 

--- a/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
+++ b/chakracore-cxx/lib/Common/Exceptions/Throw.cpp
@@ -131,8 +131,6 @@ namespace Js {
         IsInAssert = true;
     }
 
-#define CHAKRA_ASSERT_CAPTION u"CHAKRA ASSERT"
-
     bool Throw::ReportAssert(const char * fileName, uint lineNumber, const char * error, const char * message)
     {
         if (AssertsToConsole)

--- a/chakracore-cxx/lib/Common/Memory/Recycler.cpp
+++ b/chakracore-cxx/lib/Common/Memory/Recycler.cpp
@@ -8,6 +8,7 @@
 
 #include "Memory/RecyclerWatsonTelemetry.h"
 #include "Memory/RecyclerObjectDumper.h"
+#include "chakra/Logger.h"
 
 #ifdef _M_AMD64
 #include "Interface/amd64.h"
@@ -6313,7 +6314,7 @@ void Recycler::VerifyCheck(bool cond, std::string_view msg, void * address, void
 {
     if (!cond)
     {
-        std::print(stderr, "RECYCLER CORRUPTION: StartAddress={} CorruptedAddress={}: {}", address, corruptedAddress, msg);
+        chakra::Logger::error(std::format("RECYCLER CORRUPTION: StartAddress={} CorruptedAddress={}: {}", address, corruptedAddress, msg));
         Js::Throw::FatalInternalError();
     }
 }

--- a/chakracore-cxx/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/chakracore-cxx/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -4,6 +4,8 @@
 //-------------------------------------------------------------------------------------------------------
 #include "RecyclerWriteBarrierManager.h"
 
+#include "chakra/Logger.h"
+
 // Initialization order
 //  AB AutoSystemInfo
 //  AD PerfCounter
@@ -238,7 +240,7 @@ X64WriteBarrierCardTableManager::Initialize()
         void * cardTableSpace = ::VirtualAlloc(NULL, _cardTableNumEntries, MEM_RESERVE, PAGE_READWRITE);
         if (!cardTableSpace) // Crash Early with a meaningful message. Otherwise the behavior is undefined.
         {
-            fprintf(stderr, "Out of Memory\n");
+            chakra::Logger::error("Out of Memory\n");
             abort();
         }
 

--- a/chakracore-cxx/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/chakracore-cxx/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -238,7 +238,7 @@ X64WriteBarrierCardTableManager::Initialize()
         void * cardTableSpace = ::VirtualAlloc(NULL, _cardTableNumEntries, MEM_RESERVE, PAGE_READWRITE);
         if (!cardTableSpace) // Crash Early with a meaningful message. Otherwise the behavior is undefined.
         {
-            fprintf(stderr, "Out of Memory\n"); fflush(stderr);
+            fprintf(stderr, "Out of Memory\n");
             abort();
         }
 

--- a/chakracore-cxx/lib/Jsrt/ChakraDebug.h
+++ b/chakracore-cxx/lib/Jsrt/ChakraDebug.h
@@ -149,20 +149,6 @@ namespace chakracore::jsrt
             _Out_opt_ void** callbackState);
 
     /// <summary>
-    ///     Request the runtime to break on next JavaScript statement.
-    /// </summary>
-    /// <param name="runtimeHandle">Runtime to request break.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    /// <remarks>
-    ///     The runtime should be in debug state. This API can be called from another runtime.
-    /// </remarks>
-    JsErrorCode
-        JsDiagRequestAsyncBreak(
-            _In_ JsRuntimeHandle runtimeHandle);
-
-    /// <summary>
     ///     List all breakpoints in the current runtime.
     /// </summary>
     /// <param name="breakpoints">Array of breakpoints.</param>

--- a/chakracore-cxx/lib/Jsrt/JsrtDebugManager.cpp
+++ b/chakracore-cxx/lib/Jsrt/JsrtDebugManager.cpp
@@ -321,27 +321,6 @@ void JsrtDebugManager::SetResumeType(BREAKRESUMEACTION resumeAction)
     this->resumeAction = resumeAction;
 }
 
-bool JsrtDebugManager::EnableAsyncBreak(Js::ScriptContext* scriptContext)
-{
-    if (!scriptContext->IsDebugContextInitialized())
-    {
-        // Although the script context exists, it hasn't been fully initialized yet.
-        return false;
-    }
-
-    Js::ProbeContainer* probeContainer = scriptContext->GetDebugContext()->GetProbeContainer();
-
-    // This can be called when we are already at break
-    if (!probeContainer->IsAsyncActivate())
-    {
-        probeContainer->AsyncActivate(this);
-
-        scriptContext->GetThreadContext()->GetDebugManager()->GetDebuggingFlags()->SetForceInterpreter(true);
-        return true;
-    }
-    return false;
-}
-
 void JsrtDebugManager::CallDebugEventCallback(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext, bool isBreak)
 {
     class AutoClear

--- a/chakracore-cxx/lib/Jsrt/JsrtDebugManager.h
+++ b/chakracore-cxx/lib/Jsrt/JsrtDebugManager.h
@@ -24,8 +24,6 @@ public:
     void HandleResume(Js::InterpreterHaltState* haltState, BREAKRESUMEACTION resumeAction);
     void SetResumeType(BREAKRESUMEACTION resumeAction);
 
-    bool EnableAsyncBreak(Js::ScriptContext* scriptContext);
-
     void CallDebugEventCallback(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext, bool isBreak);
     void CallDebugEventCallbackForBreak(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext);
 

--- a/chakracore-cxx/lib/Jsrt/JsrtDiag.cpp
+++ b/chakracore-cxx/lib/Jsrt/JsrtDiag.cpp
@@ -233,34 +233,6 @@ JsErrorCode chakracore::jsrt::JsDiagGetSource(
 #endif
 }
 
-JsErrorCode chakracore::jsrt::JsDiagRequestAsyncBreak(
-    _In_ JsRuntimeHandle runtimeHandle)
-{
-#ifndef ENABLE_SCRIPT_DEBUGGING
-    return JsErrorCategoryUsage;
-#else
-    return GlobalAPIWrapper_NoRecord([&]() -> JsErrorCode {
-
-        VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
-
-        JsrtRuntime * runtime = JsrtRuntime::FromHandle(runtimeHandle);
-
-        JsrtDebugManager* jsrtDebugManager = runtime->GetJsrtDebugManager();
-
-        VALIDATE_IS_DEBUGGING(jsrtDebugManager);
-
-        for (Js::ScriptContext *scriptContext = runtime->GetThreadContext()->GetScriptContextList();
-        scriptContext != nullptr && !scriptContext->IsClosed();
-            scriptContext = scriptContext->next)
-        {
-            jsrtDebugManager->EnableAsyncBreak(scriptContext);
-        }
-
-        return JsNoError;
-    });
-#endif
-}
-
 JsErrorCode chakracore::jsrt::JsDiagGetBreakpoints(
     _Out_ JsValueRef *breakpoints)
 {

--- a/chakracore-cxx/lib/Runtime/Debug/ProbeContainer.cpp
+++ b/chakracore-cxx/lib/Runtime/Debug/ProbeContainer.cpp
@@ -953,11 +953,6 @@ namespace Js
         debugManager->asyncBreakController.Deactivate();
     }
 
-    bool ProbeContainer::IsAsyncActivate() const
-    {
-        return this->pAsyncHaltCallback != nullptr;
-    }
-
     void ProbeContainer::PrepDiagForEnterScript()
     {
         // This will be called from ParseScriptText.

--- a/chakracore-cxx/lib/Runtime/Debug/ProbeContainer.h
+++ b/chakracore-cxx/lib/Runtime/Debug/ProbeContainer.h
@@ -153,7 +153,6 @@ namespace Js
 
         void AsyncActivate(HaltCallback* haltCallback);
         void AsyncDeactivate();
-        bool IsAsyncActivate() const;
 
         void PrepDiagForEnterScript();
 

--- a/chakracore-cxx/pal/inc/pal.h
+++ b/chakracore-cxx/pal/inc/pal.h
@@ -263,7 +263,6 @@ WriteFile(
 
 #define STD_INPUT_HANDLE         (static_cast<uint32_t>(-10))
 #define STD_OUTPUT_HANDLE        (static_cast<uint32_t>(-11))
-#define STD_ERROR_HANDLE         (static_cast<uint32_t>(-12))
 
 HANDLE
 GetStdHandle(

--- a/chakracore-cxx/pal/inc/pal.h
+++ b/chakracore-cxx/pal/inc/pal.h
@@ -55,9 +55,8 @@ Abstract:
 #include "TargetConditionals.h"
 #endif // __APPLE__ ?
 
+// TODO (hanhossain): can remove, might need to include <cstdarg>
 typedef __builtin_va_list va_list;
-#define PRINT_ERROR(...) \
-    fprintf(stderr, __VA_ARGS__)
 
 #ifdef  __cplusplus
 extern "C" {

--- a/chakracore-cxx/pal/src/cruntime/file.cpp
+++ b/chakracore-cxx/pal/src/cruntime/file.cpp
@@ -64,7 +64,7 @@ static char* MapFileOpenModes(char* str)
 
     if (NULL == str)
     {
-        ASSERT("MapFileOpenModes called with a NULL parameter for str.\n");
+        fprintf(stderr, "MapFileOpenModes called with a NULL parameter for str.\n");
         return NULL;
     }
 
@@ -92,7 +92,7 @@ static char* MapFileOpenModes(char* str)
     The PAL does not support this behavior. */
     if (NULL != strchr(str,'D'))
     {
-        ASSERT("The PAL doesn't support the 'D' flag for _fdopen and fopen.\n");
+        fprintf(stderr, "The PAL doesn't support the 'D' flag for _fdopen and fopen.\n");
         return NULL;
     }
 

--- a/chakracore-cxx/pal/src/cruntime/file.cpp
+++ b/chakracore-cxx/pal/src/cruntime/file.cpp
@@ -30,6 +30,7 @@ Abstract:
 #include <sys/stat.h>
 #include <pthread.h>
 #include <limits.h>
+#include "chakra/Logger.h"
 
     #define CLEARERR(f)
 
@@ -64,7 +65,7 @@ static char* MapFileOpenModes(char* str)
 
     if (NULL == str)
     {
-        fprintf(stderr, "MapFileOpenModes called with a NULL parameter for str.\n");
+        chakra::Logger::error("MapFileOpenModes called with a NULL parameter for str.\n");
         return NULL;
     }
 
@@ -92,7 +93,7 @@ static char* MapFileOpenModes(char* str)
     The PAL does not support this behavior. */
     if (NULL != strchr(str,'D'))
     {
-        fprintf(stderr, "The PAL doesn't support the 'D' flag for _fdopen and fopen.\n");
+        chakra::Logger::error("The PAL doesn't support the 'D' flag for _fdopen and fopen.\n");
         return NULL;
     }
 

--- a/chakracore-cxx/pal/src/cruntime/printf.cpp
+++ b/chakracore-cxx/pal/src/cruntime/printf.cpp
@@ -28,6 +28,8 @@ Revision History:
 #include "pal/thread.hpp"
 #include "pal/threadsusp.hpp"
 #include "pal/printfcpp.hpp"
+#include "chakra/Logger.h"
+#include <format>
 
 /* <stdarg.h> needs to be included after "palinternal.h" to avoid name
    collision for va_start and va_end */
@@ -527,8 +529,8 @@ int PAL_wvsscanf(const char16_t* Buffer, const char16_t* Format, va_list ap)
                 size = WideCharToMultiByte(CP_ACP, 0, Buff, -1, 0, 0, 0);
                 if (!size)
                 {
-                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                        GetLastError());
+                    chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                        GetLastError()));
                     return -1;
                 }
                 newBuff = static_cast<char*>(malloc(size));
@@ -542,8 +544,8 @@ int PAL_wvsscanf(const char16_t* Buffer, const char16_t* Format, va_list ap)
                                            newBuff, size, 0);
                 if (!size)
                 {
-                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                        GetLastError());
+                    chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                        GetLastError()));
                     free(newBuff);
                     return -1;
                 }

--- a/chakracore-cxx/pal/src/cruntime/printf.cpp
+++ b/chakracore-cxx/pal/src/cruntime/printf.cpp
@@ -527,7 +527,7 @@ int PAL_wvsscanf(const char16_t* Buffer, const char16_t* Format, va_list ap)
                 size = WideCharToMultiByte(CP_ACP, 0, Buff, -1, 0, 0, 0);
                 if (!size)
                 {
-                    ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                         GetLastError());
                     return -1;
                 }
@@ -542,7 +542,7 @@ int PAL_wvsscanf(const char16_t* Buffer, const char16_t* Format, va_list ap)
                                            newBuff, size, 0);
                 if (!size)
                 {
-                    ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                         GetLastError());
                     free(newBuff);
                     return -1;

--- a/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
+++ b/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
@@ -30,6 +30,7 @@ Revision History:
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
 #include "pal/cruntime.h"
+#include "chakra/Logger.h"
 
 #include <errno.h>
 
@@ -1167,7 +1168,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, FILE *stream, const char16_t *format,
                     }
                     else
                     {
-                        fprintf(stderr, "Unable to convert from multibyte "
+                        chakra::Logger::error("Unable to convert from multibyte "
                                " to wide char.\n" );
                         LOGEXIT("vfwprintf returns int -1\n");
                         va_end(ap);
@@ -1581,7 +1582,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                     }
                     else
                     {
-                        fprintf(stderr, "Unable to convert from multibyte "
+                        chakra::Logger::error("Unable to convert from multibyte "
                                " to wide char.\n" );
                         va_end(ap);
                         return -1;
@@ -1765,7 +1766,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
 
                     if (strncpy_s(TempNumberBuffer, TempCount+1, reinterpret_cast<char*>(BufferPtr), TempCount) != SAFECRT_SUCCESS)
                     {
-                        fprintf(stderr, "strncpy_s failed!\n");
+                        chakra::Logger::error("strncpy_s failed!\n");
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
@@ -1799,7 +1800,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
 
                     if (strncpy_s(TempNumberBuffer, TempInt+1, reinterpret_cast<char*>(BufferPtr), TempInt) != SAFECRT_SUCCESS)
                     {
-                        fprintf(stderr, "strncpy_s failed!\n");
+                        chakra::Logger::error("strncpy_s failed!\n");
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;

--- a/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
+++ b/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
@@ -62,7 +62,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
         nsize = WideCharToMultiByte(CP_ACP, 0,static_cast<const char16_t*>(buffer), count, 0, 0, 0);
         if (!nsize)
         {
-            ASSERT("WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+            fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
             return -1;
         }
         newBuff = static_cast<char*>(malloc(nsize));
@@ -75,7 +75,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
         nsize = WideCharToMultiByte(CP_ACP, 0, static_cast<const char16_t*>(buffer), count, newBuff, nsize, 0);
         if (!nsize)
         {
-            ASSERT("WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+            fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
             free(newBuff);
             return -1;
         }
@@ -1167,7 +1167,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, FILE *stream, const char16_t *format,
                     }
                     else
                     {
-                        ASSERT( "Unable to convert from multibyte "
+                        fprintf(stderr, "Unable to convert from multibyte "
                                " to wide char.\n" );
                         LOGEXIT("vfwprintf returns int -1\n");
                         va_end(ap);
@@ -1581,7 +1581,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                     }
                     else
                     {
-                        ASSERT( "Unable to convert from multibyte "
+                        fprintf(stderr, "Unable to convert from multibyte "
                                " to wide char.\n" );
                         va_end(ap);
                         return -1;
@@ -1765,7 +1765,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
 
                     if (strncpy_s(TempNumberBuffer, TempCount+1, reinterpret_cast<char*>(BufferPtr), TempCount) != SAFECRT_SUCCESS)
                     {
-                        ASSERT("strncpy_s failed!\n");
+                        fprintf(stderr, "strncpy_s failed!\n");
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
@@ -1777,7 +1777,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                                                        BufferPtr, TempCount);
                     if (!mbtowcResult)
                     {
-                        ASSERT("MultiByteToWideChar failed.  Error is %d\n",
+                        fprintf(stderr, "MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
                         free(TempNumberBuffer);
                         va_end(ap);
@@ -1799,7 +1799,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
 
                     if (strncpy_s(TempNumberBuffer, TempInt+1, reinterpret_cast<char*>(BufferPtr), TempInt) != SAFECRT_SUCCESS)
                     {
-                        ASSERT("strncpy_s failed!\n");
+                        fprintf(stderr, "strncpy_s failed!\n");
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
@@ -1811,7 +1811,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                                                        BufferPtr, TempInt);
                     if (!mbtowcResult)
                     {
-                        ASSERT("MultiByteToWideChar failed.  Error is %d\n",
+                        fprintf(stderr, "MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
                         free(TempNumberBuffer);
                         va_end(ap);
@@ -1902,7 +1902,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                              0, 0);
                 if (!Length)
                 {
-                    ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                         GetLastError());
                     va_end(ap);
                     return -1;
@@ -1927,7 +1927,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                                  Precision, TempStr, Length, 0);
                     if (!Length)
                     {
-                        ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
                         free(TempStr);
                         va_end(ap);
@@ -1943,7 +1943,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                                        TempStr, Length, 0);
                     if (!wctombResult)
                     {
-                        ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
                         free(TempStr);
                         va_end(ap);
@@ -1988,7 +1988,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                              TempBuffer, sizeof(TempBuffer), 0);
                 if (!Length)
                 {
-                    ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
                           GetLastError());
                     va_end(ap);
                     return -1;

--- a/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
+++ b/chakracore-cxx/pal/src/cruntime/printfcpp.cpp
@@ -32,6 +32,7 @@ Revision History:
 #include "pal/cruntime.h"
 #include "chakra/Logger.h"
 
+#include <format>
 #include <errno.h>
 
 SET_DEFAULT_DEBUG_CHANNEL(CRT);
@@ -63,7 +64,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
         nsize = WideCharToMultiByte(CP_ACP, 0,static_cast<const char16_t*>(buffer), count, 0, 0, 0);
         if (!nsize)
         {
-            fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+            chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n", GetLastError()));
             return -1;
         }
         newBuff = static_cast<char*>(malloc(nsize));
@@ -76,7 +77,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
         nsize = WideCharToMultiByte(CP_ACP, 0, static_cast<const char16_t*>(buffer), count, newBuff, nsize, 0);
         if (!nsize)
         {
-            fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+            chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n", GetLastError()));
             free(newBuff);
             return -1;
         }
@@ -1778,8 +1779,8 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                                                        BufferPtr, TempCount);
                     if (!mbtowcResult)
                     {
-                        fprintf(stderr, "MultiByteToWideChar failed.  Error is %d\n",
-                              GetLastError());
+                        chakra::Logger::error(std::format("MultiByteToWideChar failed.  Error is {}\n",
+                              GetLastError()));
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
@@ -1812,8 +1813,8 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, char16_t* Buffer, size_t Count, cons
                                                        BufferPtr, TempInt);
                     if (!mbtowcResult)
                     {
-                        fprintf(stderr, "MultiByteToWideChar failed.  Error is %d\n",
-                              GetLastError());
+                        chakra::Logger::error(std::format("MultiByteToWideChar failed.  Error is {}\n",
+                              GetLastError()));
                         free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
@@ -1903,8 +1904,8 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                              0, 0);
                 if (!Length)
                 {
-                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                        GetLastError());
+                    chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                        GetLastError()));
                     va_end(ap);
                     return -1;
                 }
@@ -1928,8 +1929,8 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                                  Precision, TempStr, Length, 0);
                     if (!Length)
                     {
-                        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                              GetLastError());
+                        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                              GetLastError()));
                         free(TempStr);
                         va_end(ap);
                         return -1;
@@ -1944,8 +1945,8 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                                        TempStr, Length, 0);
                     if (!wctombResult)
                     {
-                        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                              GetLastError());
+                        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                              GetLastError()));
                         free(TempStr);
                         va_end(ap);
                         return -1;
@@ -1989,8 +1990,8 @@ int CoreVfprintf(CPalThread *pthrCurrent, FILE *stream, const char *format, va_l
                                              TempBuffer, sizeof(TempBuffer), 0);
                 if (!Length)
                 {
-                    fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-                          GetLastError());
+                    chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+                          GetLastError()));
                     va_end(ap);
                     return -1;
                 }

--- a/chakracore-cxx/pal/src/cruntime/wchar.cpp
+++ b/chakracore-cxx/pal/src/cruntime/wchar.cpp
@@ -95,7 +95,7 @@ char16_t* Internal_i64tow(int64_t value, char16_t* string, int radix, BOOL isI64
 
     if (radix < 2 || radix > 36)
     {
-        ASSERT( "Invalid radix, radix must be between 2 and 36\n" );
+        fprintf(stderr, "Invalid radix, radix must be between 2 and 36\n" );
         SetLastError(ERROR_INVALID_PARAMETER);
         return string;
     }
@@ -231,7 +231,7 @@ _wtoi(
     len = WideCharToMultiByte(CP_ACP, 0, string, -1, 0, 0, 0);
     if (!len)
     {
-        ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
               GetLastError());
         return -1;
     }
@@ -245,7 +245,7 @@ _wtoi(
     len = WideCharToMultiByte(CP_ACP, 0, string, -1, tempStr, len, 0);
     if (!len)
     {
-        ASSERT("WideCharToMultiByte failed.  Error is %d\n",
+        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
               GetLastError());
         free(tempStr);
         return -1;
@@ -306,7 +306,7 @@ PAL__wcstoui64(
     size = WideCharToMultiByte(CP_ACP, 0, nptr, -1, NULL, 0, NULL);
     if (!size)
     {
-        ASSERT("WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
         SetLastError(ERROR_INVALID_PARAMETER);
         res = 0;
         goto PAL__wcstoui64Exit;
@@ -322,7 +322,7 @@ PAL__wcstoui64(
     size = WideCharToMultiByte(CP_ACP, 0, nptr, -1, s_nptr, size, NULL);
     if (!size)
     {
-        ASSERT("WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
         SetLastError(ERROR_INVALID_PARAMETER);
         res = 0;
         goto PAL__wcstoui64Exit;

--- a/chakracore-cxx/pal/src/cruntime/wchar.cpp
+++ b/chakracore-cxx/pal/src/cruntime/wchar.cpp
@@ -27,6 +27,7 @@ Abstract:
 
 #include "pal/thread.hpp"
 #include "pal/threadsusp.hpp"
+#include "chakra/Logger.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -95,7 +96,7 @@ char16_t* Internal_i64tow(int64_t value, char16_t* string, int radix, BOOL isI64
 
     if (radix < 2 || radix > 36)
     {
-        fprintf(stderr, "Invalid radix, radix must be between 2 and 36\n" );
+        chakra::Logger::error("Invalid radix, radix must be between 2 and 36\n" );
         SetLastError(ERROR_INVALID_PARAMETER);
         return string;
     }

--- a/chakracore-cxx/pal/src/cruntime/wchar.cpp
+++ b/chakracore-cxx/pal/src/cruntime/wchar.cpp
@@ -31,6 +31,7 @@ Abstract:
 
 #include <errno.h>
 #include <limits.h>
+#include <format>
 
 SET_DEFAULT_DEBUG_CHANNEL(CRT);
 
@@ -232,8 +233,8 @@ _wtoi(
     len = WideCharToMultiByte(CP_ACP, 0, string, -1, 0, 0, 0);
     if (!len)
     {
-        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-              GetLastError());
+        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+              GetLastError()));
         return -1;
     }
     tempStr = static_cast<char*>(malloc(len));
@@ -246,8 +247,8 @@ _wtoi(
     len = WideCharToMultiByte(CP_ACP, 0, string, -1, tempStr, len, 0);
     if (!len)
     {
-        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n",
-              GetLastError());
+        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n",
+              GetLastError()));
         free(tempStr);
         return -1;
     }
@@ -307,7 +308,7 @@ PAL__wcstoui64(
     size = WideCharToMultiByte(CP_ACP, 0, nptr, -1, NULL, 0, NULL);
     if (!size)
     {
-        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n", GetLastError()));
         SetLastError(ERROR_INVALID_PARAMETER);
         res = 0;
         goto PAL__wcstoui64Exit;
@@ -323,7 +324,7 @@ PAL__wcstoui64(
     size = WideCharToMultiByte(CP_ACP, 0, nptr, -1, s_nptr, size, NULL);
     if (!size)
     {
-        fprintf(stderr, "WideCharToMultiByte failed.  Error is %d\n", GetLastError());
+        chakra::Logger::error(std::format("WideCharToMultiByte failed.  Error is {}\n", GetLastError()));
         SetLastError(ERROR_INVALID_PARAMETER);
         res = 0;
         goto PAL__wcstoui64Exit;

--- a/chakracore-cxx/pal/src/exception/machexception.cpp
+++ b/chakracore-cxx/pal/src/exception/machexception.cpp
@@ -231,7 +231,7 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
         countBits = ((countBits & 0xFFFF0000) >> 16) + (countBits & 0x0000FFFF);
         if (countBits != static_cast<exception_mask_t>(CThreadMachExceptionHandlers::s_nPortsMax))
         {
-            ASSERT("s_nPortsMax is %u, but needs to be %u\n",
+            fprintf(stderr, "s_nPortsMax is %u, but needs to be %u\n",
                    CThreadMachExceptionHandlers::s_nPortsMax, countBits);
         }
 #endif // _DEBUG
@@ -265,7 +265,7 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
 
         if (machret != KERN_SUCCESS)
         {
-            ASSERT("thread_swap_exception_ports failed: %d %s\n", machret, mach_error_string(machret));
+            fprintf(stderr, "thread_swap_exception_ports failed: %d %s\n", machret, mach_error_string(machret));
             return UTIL_MachErrorToPalError(machret);
         }
 
@@ -336,7 +336,7 @@ PAL_ERROR CorUnix::CPalThread::DisableMachExceptions()
 
     if (MachRet != KERN_SUCCESS)
     {
-        ASSERT("thread_set_exception_ports failed: %d\n", MachRet);
+        fprintf(stderr, "thread_set_exception_ports failed: %d\n", MachRet);
         palError = UTIL_MachErrorToPalError(MachRet);
     }
 
@@ -1177,7 +1177,7 @@ bool SEHInitializeMachExceptions()
     machret = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &s_ExceptionPort);
     if (machret != KERN_SUCCESS)
     {
-        ASSERT("mach_port_allocate failed: %d\n", machret);
+        fprintf(stderr, "mach_port_allocate failed: %d\n", machret);
         UTIL_SetLastErrorFromMach(machret);
         return true;
     }
@@ -1186,7 +1186,7 @@ bool SEHInitializeMachExceptions()
     machret = mach_port_insert_right(mach_task_self(), s_ExceptionPort, s_ExceptionPort, MACH_MSG_TYPE_MAKE_SEND);
     if (machret != KERN_SUCCESS)
     {
-        ASSERT("mach_port_insert_right failed: %d\n", machret);
+        fprintf(stderr, "mach_port_insert_right failed: %d\n", machret);
         UTIL_SetLastErrorFromMach(machret);
         return false;
     }

--- a/chakracore-cxx/pal/src/exception/machexception.cpp
+++ b/chakracore-cxx/pal/src/exception/machexception.cpp
@@ -44,6 +44,8 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 #include <dlfcn.h>
 #include <mach-o/loader.h>
 #include <sys/mman.h>
+#include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -231,8 +233,8 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
         countBits = ((countBits & 0xFFFF0000) >> 16) + (countBits & 0x0000FFFF);
         if (countBits != static_cast<exception_mask_t>(CThreadMachExceptionHandlers::s_nPortsMax))
         {
-            fprintf(stderr, "s_nPortsMax is %u, but needs to be %u\n",
-                   CThreadMachExceptionHandlers::s_nPortsMax, countBits);
+            chakra::Logger::error(std::format("s_nPortsMax is {}, but needs to be {}\n",
+                   CThreadMachExceptionHandlers::s_nPortsMax, countBits));
         }
 #endif // _DEBUG
 
@@ -265,7 +267,7 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
 
         if (machret != KERN_SUCCESS)
         {
-            fprintf(stderr, "thread_swap_exception_ports failed: %d %s\n", machret, mach_error_string(machret));
+            chakra::Logger::error(std::format("thread_swap_exception_ports failed: {} {}\n", machret, mach_error_string(machret)));
             return UTIL_MachErrorToPalError(machret);
         }
 
@@ -336,7 +338,7 @@ PAL_ERROR CorUnix::CPalThread::DisableMachExceptions()
 
     if (MachRet != KERN_SUCCESS)
     {
-        fprintf(stderr, "thread_set_exception_ports failed: %d\n", MachRet);
+        chakra::Logger::error(std::format("thread_set_exception_ports failed: {}\n", MachRet));
         palError = UTIL_MachErrorToPalError(MachRet);
     }
 
@@ -1177,7 +1179,7 @@ bool SEHInitializeMachExceptions()
     machret = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &s_ExceptionPort);
     if (machret != KERN_SUCCESS)
     {
-        fprintf(stderr, "mach_port_allocate failed: %d\n", machret);
+        chakra::Logger::error(std::format("mach_port_allocate failed: {}\n", machret));
         UTIL_SetLastErrorFromMach(machret);
         return true;
     }
@@ -1186,7 +1188,7 @@ bool SEHInitializeMachExceptions()
     machret = mach_port_insert_right(mach_task_self(), s_ExceptionPort, s_ExceptionPort, MACH_MSG_TYPE_MAKE_SEND);
     if (machret != KERN_SUCCESS)
     {
-        fprintf(stderr, "mach_port_insert_right failed: %d\n", machret);
+        chakra::Logger::error(std::format("mach_port_insert_right failed: {}\n", machret));
         UTIL_SetLastErrorFromMach(machret);
         return false;
     }

--- a/chakracore-cxx/pal/src/exception/signal.cpp
+++ b/chakracore-cxx/pal/src/exception/signal.cpp
@@ -44,6 +44,7 @@ Abstract:
 
 #include "pal/context.h"
 #include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -506,7 +507,7 @@ static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
     sigaddset(&signal_set, code);
     if(-1 == sigprocmask(SIG_UNBLOCK, &signal_set, NULL))
     {
-        fprintf(stderr, "sigprocmask failed; error is %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("sigprocmask failed; error is {} ({})\n", errno, strerror(errno)));
     }
 
     // We do nothing further
@@ -541,8 +542,8 @@ void handle_signal(int signal_id, SIGFUNC sigfunc, struct sigaction *previousAct
 
     if (-1 == sigaction(signal_id, &newAction, previousAction))
     {
-        fprintf(stderr, "handle_signal: sigaction() call failed with error code %d (%s)\n",
-            errno, strerror(errno));
+        chakra::Logger::error(std::format("handle_signal: sigaction() call failed with error code {} ({})\n",
+            errno, strerror(errno)));
     }
 }
 
@@ -562,8 +563,8 @@ void restore_signal(int signal_id, struct sigaction *previousAction)
 {
     if (-1 == sigaction(signal_id, previousAction, NULL))
     {
-        fprintf(stderr, "restore_signal: sigaction() call failed with error code %d (%s)\n",
-            errno, strerror(errno));
+        chakra::Logger::error(std::format("restore_signal: sigaction() call failed with error code {} ({})\n",
+            errno, strerror(errno)));
     }
 }
 

--- a/chakracore-cxx/pal/src/exception/signal.cpp
+++ b/chakracore-cxx/pal/src/exception/signal.cpp
@@ -439,7 +439,7 @@ void SEHSetSafeState(CPalThread *pthrCurrent, BOOL state)
 {
     if (NULL == pthrCurrent)
     {
-        ASSERT( "Unable to get the thread object.\n" );
+        fprintf(stderr, "Unable to get the thread object.\n" );
         return;
     }
     pthrCurrent->sehInfo.safe_state = state;
@@ -461,7 +461,7 @@ BOOL SEHGetSafeState(CPalThread *pthrCurrent)
 {
     if (NULL == pthrCurrent)
     {
-        ASSERT( "Unable to get the thread object.\n" );
+        fprintf(stderr, "Unable to get the thread object.\n" );
         return FALSE;
     }
     return pthrCurrent->sehInfo.safe_state;
@@ -505,7 +505,7 @@ static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
     sigaddset(&signal_set, code);
     if(-1 == sigprocmask(SIG_UNBLOCK, &signal_set, NULL))
     {
-        ASSERT("sigprocmask failed; error is %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "sigprocmask failed; error is %d (%s)\n", errno, strerror(errno));
     }
 
     // We do nothing further
@@ -540,7 +540,7 @@ void handle_signal(int signal_id, SIGFUNC sigfunc, struct sigaction *previousAct
 
     if (-1 == sigaction(signal_id, &newAction, previousAction))
     {
-        ASSERT("handle_signal: sigaction() call failed with error code %d (%s)\n",
+        fprintf(stderr, "handle_signal: sigaction() call failed with error code %d (%s)\n",
             errno, strerror(errno));
     }
 }
@@ -561,7 +561,7 @@ void restore_signal(int signal_id, struct sigaction *previousAction)
 {
     if (-1 == sigaction(signal_id, previousAction, NULL))
     {
-        ASSERT("restore_signal: sigaction() call failed with error code %d (%s)\n",
+        fprintf(stderr, "restore_signal: sigaction() call failed with error code %d (%s)\n",
             errno, strerror(errno));
     }
 }

--- a/chakracore-cxx/pal/src/exception/signal.cpp
+++ b/chakracore-cxx/pal/src/exception/signal.cpp
@@ -43,6 +43,7 @@ Abstract:
 #include <unistd.h>
 
 #include "pal/context.h"
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -439,7 +440,7 @@ void SEHSetSafeState(CPalThread *pthrCurrent, BOOL state)
 {
     if (NULL == pthrCurrent)
     {
-        fprintf(stderr, "Unable to get the thread object.\n" );
+        chakra::Logger::error("Unable to get the thread object.\n" );
         return;
     }
     pthrCurrent->sehInfo.safe_state = state;
@@ -461,7 +462,7 @@ BOOL SEHGetSafeState(CPalThread *pthrCurrent)
 {
     if (NULL == pthrCurrent)
     {
-        fprintf(stderr, "Unable to get the thread object.\n" );
+        chakra::Logger::error("Unable to get the thread object.\n" );
         return FALSE;
     }
     return pthrCurrent->sehInfo.safe_state;

--- a/chakracore-cxx/pal/src/file/pal_file.cpp
+++ b/chakracore-cxx/pal/src/file/pal_file.cpp
@@ -41,6 +41,7 @@ Abstract:
 #include <sys/mount.h>
 #include <errno.h>
 #include <limits.h>
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -94,7 +95,7 @@ void FileCleanupRoutine(CPalThread *pThread, IPalObject *pObjectToCleanup, bool 
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Unable to obtain data to cleanup file object");
+        chakra::Logger::error("Unable to obtain data to cleanup file object");
         return;
     }
 
@@ -151,7 +152,7 @@ void FILEGetProperNotFoundError( char* lpPath, uint32_t * lpErrorCode )
 
     if ( !lpErrorCode )
     {
-        fprintf(stderr, "lpErrorCode has to be valid\n" );
+        chakra::Logger::error("lpErrorCode has to be valid\n" );
         return;
     }
 
@@ -251,7 +252,7 @@ CorUnix::InternalWriteFile(
     }
     else
     {
-        fprintf(stderr, "lpNumberOfBytesWritten is NULL\n" );
+        chakra::Logger::error("lpNumberOfBytesWritten is NULL\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto done;
     }
@@ -264,7 +265,7 @@ CorUnix::InternalWriteFile(
     }
     else if ( lpOverlapped )
     {
-        fprintf(stderr, "lpOverlapped is not NULL, as it should be.\n" );
+        chakra::Logger::error("lpOverlapped is not NULL, as it should be.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto done;
     }
@@ -320,7 +321,7 @@ CorUnix::InternalWriteFile(
 
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Failed to get the current file position\n");
+            chakra::Logger::error("Failed to get the current file position\n");
             palError = ERROR_INTERNAL_ERROR;
             goto done;
         }

--- a/chakracore-cxx/pal/src/file/pal_file.cpp
+++ b/chakracore-cxx/pal/src/file/pal_file.cpp
@@ -94,7 +94,7 @@ void FileCleanupRoutine(CPalThread *pThread, IPalObject *pObjectToCleanup, bool 
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Unable to obtain data to cleanup file object");
+        fprintf(stderr, "Unable to obtain data to cleanup file object");
         return;
     }
 
@@ -151,7 +151,7 @@ void FILEGetProperNotFoundError( char* lpPath, uint32_t * lpErrorCode )
 
     if ( !lpErrorCode )
     {
-        ASSERT( "lpErrorCode has to be valid\n" );
+        fprintf(stderr, "lpErrorCode has to be valid\n" );
         return;
     }
 
@@ -251,7 +251,7 @@ CorUnix::InternalWriteFile(
     }
     else
     {
-        ASSERT( "lpNumberOfBytesWritten is NULL\n" );
+        fprintf(stderr, "lpNumberOfBytesWritten is NULL\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto done;
     }
@@ -264,7 +264,7 @@ CorUnix::InternalWriteFile(
     }
     else if ( lpOverlapped )
     {
-        ASSERT( "lpOverlapped is not NULL, as it should be.\n" );
+        fprintf(stderr, "lpOverlapped is not NULL, as it should be.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto done;
     }
@@ -320,7 +320,7 @@ CorUnix::InternalWriteFile(
 
         if (NO_ERROR != palError)
         {
-            ASSERT("Failed to get the current file position\n");
+            fprintf(stderr, "Failed to get the current file position\n");
             palError = ERROR_INTERNAL_ERROR;
             goto done;
         }

--- a/chakracore-cxx/pal/src/file/pal_file.cpp
+++ b/chakracore-cxx/pal/src/file/pal_file.cpp
@@ -130,7 +130,6 @@ before any other functions and if it is not successful,
 no other functions should be done. */
 static HANDLE pStdIn;
 static HANDLE pStdOut;
-static HANDLE pStdErr;
 
 /*++
 Function : 
@@ -444,9 +443,6 @@ GetStdHandle(
         break;
     case STD_OUTPUT_HANDLE:
         hRet = pStdOut;
-        break;
-    case STD_ERROR_HANDLE:
-        hRet = pStdErr; 
         break;
     default:
         ERROR("nStdHandle is invalid\n");
@@ -836,7 +832,6 @@ BOOL FILEInitStdHandles(void)
 {
     HANDLE stdin_handle;
     HANDLE stdout_handle;
-    HANDLE stderr_handle;
 
     TRACE("creating handle objects for stdin, stdout, stderr\n");
 
@@ -855,20 +850,11 @@ BOOL FILEInitStdHandles(void)
         goto fail;
     }
 
-    stderr_handle = init_std_handle(&pStdErr, stderr);
-    if(INVALID_HANDLE_VALUE == stderr_handle)
-    {
-        ERROR("failed to create stderr handle\n");
-        CloseHandle(stdin_handle);
-        CloseHandle(stdout_handle);
-        goto fail;
-    }
     return TRUE;
 
 fail:
     pStdIn = INVALID_HANDLE_VALUE;
     pStdOut = INVALID_HANDLE_VALUE;
-    pStdErr = INVALID_HANDLE_VALUE;
     return FALSE;
 }
 
@@ -885,16 +871,12 @@ void FILECleanupStdHandles(void)
 {
     HANDLE stdin_handle;
     HANDLE stdout_handle;
-    HANDLE stderr_handle;
 
     TRACE("closing standard handles\n");
     stdin_handle = pStdIn;
     stdout_handle = pStdOut;
-    stderr_handle = pStdErr;
     pStdIn = INVALID_HANDLE_VALUE;
     pStdOut = INVALID_HANDLE_VALUE;
-    pStdErr = INVALID_HANDLE_VALUE;
     CloseHandle(stdin_handle);
     CloseHandle(stdout_handle);
-    CloseHandle(stderr_handle);
 }

--- a/chakracore-cxx/pal/src/file/shmfilelockmgr.cpp
+++ b/chakracore-cxx/pal/src/file/shmfilelockmgr.cpp
@@ -194,7 +194,7 @@ FILELockFileRegion(
     
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE || fileLocks == NULL)
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -206,7 +206,7 @@ FILELockFileRegion(
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, fileLocks->fileLockedRgns) 
             == FALSE)
         {
-            ASSERT("Unable to get pointer from shm pointer.\n");
+            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -222,7 +222,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -244,7 +244,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -269,7 +269,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -347,7 +347,7 @@ FILEUnlockFileRegion(
         (fileLocks == NULL) ||
         (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, fileLocks->fileLockedRgns) == FALSE))
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -366,7 +366,7 @@ FILEUnlockFileRegion(
         shmcurLockRgn = curLockRgn->next;
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
         {
-            ASSERT("Unable to get pointer from shm pointer.\n");
+            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
             goto EXIT;
         }
     }
@@ -422,7 +422,7 @@ FILEGetSHMFileLocks(
         if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, filelocksPtr, shmPtrRet) == FALSE) ||
              (SHMPTR_TO_TYPED_PTR_BOOL(char, unix_filename, filelocksPtr->unix_filename) == FALSE))
         {
-            ASSERT("Unable to get pointer from shm pointer.\n");
+            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -462,7 +462,7 @@ FILEGetSHMFileLocks(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, filelocksPtr, shmPtrRet) == FALSE)
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto CLEANUP1;
     }
@@ -485,7 +485,7 @@ FILEGetSHMFileLocks(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, nextFilelocksPtr, filelocksPtr->next) == FALSE)
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto CLEANUP2;
     }
@@ -530,7 +530,7 @@ FILEAddNewLockedRgn(
 
     if ((fileLocks == NULL) || (pvControllerInstance == NULL))
     {
-        ASSERT("Invalid Null parameter.\n");
+        fprintf(stderr, "Invalid Null parameter.\n");
         return FALSE;
     }
 
@@ -549,7 +549,7 @@ FILEAddNewLockedRgn(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, newLockRgn, shmNewLockRgn) == FALSE)
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -566,7 +566,7 @@ FILEAddNewLockedRgn(
     {
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, insertAfter->next) == FALSE)
         {
-            ASSERT("Unable to get pointer from shm pointer.\n");
+            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -575,7 +575,7 @@ FILEAddNewLockedRgn(
     {
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, fileLocks->fileLockedRgns) == FALSE)
         {
-            ASSERT("Unable to get pointer from shm pointer.\n");
+            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -589,7 +589,7 @@ FILEAddNewLockedRgn(
             insertAfter = lockRgnPtr;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, lockRgnPtr->next) == FALSE)
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -640,7 +640,7 @@ FILECleanUpLockedRgn(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE)
     {
-        ASSERT("Unable to get pointer from shm pointer.\n");
+        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
         goto EXIT;
     }
 
@@ -651,7 +651,7 @@ FILECleanUpLockedRgn(
             shmcurLockRgn = fileLocks->fileLockedRgns;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 goto EXIT;
             }
             
@@ -672,7 +672,7 @@ FILECleanUpLockedRgn(
                         shmcurLockRgn = fileLocks->fileLockedRgns;
                         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                         {
-                            ASSERT("Unable to get pointer from shm pointer.\n");
+                            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                             goto EXIT;
                         }
                     }
@@ -683,7 +683,7 @@ FILECleanUpLockedRgn(
                         shmcurLockRgn = prevLock->next;
                         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                         {
-                            ASSERT("Unable to get pointer from shm pointer.\n");
+                            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                             goto EXIT;
                         }
                     }
@@ -694,7 +694,7 @@ FILECleanUpLockedRgn(
                 shmcurLockRgn = curLockRgn->next;
                 if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                 {
-                    ASSERT("Unable to get pointer from shm pointer.\n");
+                    fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                     goto EXIT;
                 }
             }
@@ -718,7 +718,7 @@ FILECleanUpLockedRgn(
             if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, prevFileLocks, fileLocks->prev) == FALSE) ||
                  (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, nextFileLocks, fileLocks->next) == FALSE))
             {
-                ASSERT("Unable to get pointer from shm pointer.\n");
+                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
                 goto EXIT;
             }
 

--- a/chakracore-cxx/pal/src/file/shmfilelockmgr.cpp
+++ b/chakracore-cxx/pal/src/file/shmfilelockmgr.cpp
@@ -22,6 +22,7 @@ Abstract:
 #include <new>
 #include "pal/dbgmsg.h"
 #include "shmfilelockmgr.hpp"
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -194,7 +195,7 @@ FILELockFileRegion(
     
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE || fileLocks == NULL)
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -206,7 +207,7 @@ FILELockFileRegion(
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, fileLocks->fileLockedRgns) 
             == FALSE)
         {
-            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -222,7 +223,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -244,7 +245,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -269,7 +270,7 @@ FILELockFileRegion(
             prevLock = curLock; 
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -347,7 +348,7 @@ FILEUnlockFileRegion(
         (fileLocks == NULL) ||
         (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, fileLocks->fileLockedRgns) == FALSE))
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -366,7 +367,7 @@ FILEUnlockFileRegion(
         shmcurLockRgn = curLockRgn->next;
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
         {
-            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
             goto EXIT;
         }
     }
@@ -422,7 +423,7 @@ FILEGetSHMFileLocks(
         if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, filelocksPtr, shmPtrRet) == FALSE) ||
              (SHMPTR_TO_TYPED_PTR_BOOL(char, unix_filename, filelocksPtr->unix_filename) == FALSE))
         {
-            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -462,7 +463,7 @@ FILEGetSHMFileLocks(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, filelocksPtr, shmPtrRet) == FALSE)
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto CLEANUP1;
     }
@@ -485,7 +486,7 @@ FILEGetSHMFileLocks(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, nextFilelocksPtr, filelocksPtr->next) == FALSE)
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto CLEANUP2;
     }
@@ -530,7 +531,7 @@ FILEAddNewLockedRgn(
 
     if ((fileLocks == NULL) || (pvControllerInstance == NULL))
     {
-        fprintf(stderr, "Invalid Null parameter.\n");
+        chakra::Logger::error("Invalid Null parameter.\n");
         return FALSE;
     }
 
@@ -549,7 +550,7 @@ FILEAddNewLockedRgn(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, newLockRgn, shmNewLockRgn) == FALSE)
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
@@ -566,7 +567,7 @@ FILEAddNewLockedRgn(
     {
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, insertAfter->next) == FALSE)
         {
-            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -575,7 +576,7 @@ FILEAddNewLockedRgn(
     {
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, fileLocks->fileLockedRgns) == FALSE)
         {
-            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
@@ -589,7 +590,7 @@ FILEAddNewLockedRgn(
             insertAfter = lockRgnPtr;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, lockRgnPtr, lockRgnPtr->next) == FALSE)
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto EXIT;
             }
@@ -640,7 +641,7 @@ FILECleanUpLockedRgn(
 
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE)
     {
-        fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+        chakra::Logger::error("Unable to get pointer from shm pointer.\n");
         goto EXIT;
     }
 
@@ -651,7 +652,7 @@ FILECleanUpLockedRgn(
             shmcurLockRgn = fileLocks->fileLockedRgns;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 goto EXIT;
             }
             
@@ -672,7 +673,7 @@ FILECleanUpLockedRgn(
                         shmcurLockRgn = fileLocks->fileLockedRgns;
                         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                         {
-                            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                             goto EXIT;
                         }
                     }
@@ -683,7 +684,7 @@ FILECleanUpLockedRgn(
                         shmcurLockRgn = prevLock->next;
                         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                         {
-                            fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                            chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                             goto EXIT;
                         }
                     }
@@ -694,7 +695,7 @@ FILECleanUpLockedRgn(
                 shmcurLockRgn = curLockRgn->next;
                 if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
                 {
-                    fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                    chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                     goto EXIT;
                 }
             }
@@ -718,7 +719,7 @@ FILECleanUpLockedRgn(
             if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, prevFileLocks, fileLocks->prev) == FALSE) ||
                  (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, nextFileLocks, fileLocks->next) == FALSE))
             {
-                fprintf(stderr, "Unable to get pointer from shm pointer.\n");
+                chakra::Logger::error("Unable to get pointer from shm pointer.\n");
                 goto EXIT;
             }
 

--- a/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
@@ -25,6 +25,7 @@ Abstract:
 #include "pal/procobj.hpp"
 #include "pal/dbgmsg.h"
 #include "pal/process.h"
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -113,7 +114,7 @@ CorUnix::InternalDuplicateHandle(
     /* Check validity of process handles */
     if (0 == source_process_id || 0 == target_process_id)
     {
-        fprintf(stderr, "Can't duplicate handle: invalid source or destination process");
+        chakra::Logger::error("Can't duplicate handle: invalid source or destination process");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
@@ -122,7 +123,7 @@ CorUnix::InternalDuplicateHandle(
     if (source_process_id != cur_process_id
         && target_process_id != cur_process_id)
     {
-        fprintf(stderr, "Can't duplicate handle : neither source or destination"
+        chakra::Logger::error("Can't duplicate handle : neither source or destination"
                "processes are from current process");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
@@ -130,7 +131,7 @@ CorUnix::InternalDuplicateHandle(
 
     if (FALSE != bInheritHandle)
     {
-        fprintf(stderr, "Can't duplicate handle : bInheritHandle is not FALSE.\n");
+        chakra::Logger::error("Can't duplicate handle : bInheritHandle is not FALSE.\n");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
@@ -160,7 +161,7 @@ CorUnix::InternalDuplicateHandle(
 
     if (NULL == phDuplicate)
     {
-        fprintf(stderr, "Can't duplicate handle : lpTargetHandle is NULL.\n");
+        chakra::Logger::error("Can't duplicate handle : lpTargetHandle is NULL.\n");
         goto InternalDuplicateHandleExit;
     }
 

--- a/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
@@ -26,6 +26,7 @@ Abstract:
 #include "pal/dbgmsg.h"
 #include "pal/process.h"
 #include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -138,23 +139,23 @@ CorUnix::InternalDuplicateHandle(
 
     if (dwOptions & ~(DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE))
     {
-        fprintf(stderr,
-            "Can't duplicate handle : dwOptions is %#x which is not "
+        chakra::Logger::error(std::format(
+            "Can't duplicate handle : dwOptions is {:#x} which is not "
             "a subset of (DUPLICATE_SAME_ACCESS|DUPLICATE_CLOSE_SOURCE) "
-            "(%#x).\n",
+            "({:#x}).\n",
             dwOptions,
-            DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE);
+            DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE));
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
     
     if (0 == (dwOptions & DUPLICATE_SAME_ACCESS))
     {
-        fprintf(stderr,
-            "Can't duplicate handle : dwOptions is %#x which does not "
+        chakra::Logger::error(std::format(
+            "Can't duplicate handle : dwOptions is {:#x} which does not "
             "include DUPLICATE_SAME_ACCESS (%#x).\n",
             dwOptions,
-            DUPLICATE_SAME_ACCESS);
+            DUPLICATE_SAME_ACCESS));
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
@@ -216,7 +217,7 @@ CorUnix::InternalDuplicateHandle(
     }
     else
     {
-        fprintf(stderr, "Duplication not supported for this special handle (%p)\n", hSource);
+        chakra::Logger::error(std::format("Duplication not supported for this special handle ({})\n", hSource));
         palError = ERROR_INVALID_HANDLE;
         goto InternalDuplicateHandleExit;
     }

--- a/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handleapi.cpp
@@ -113,7 +113,7 @@ CorUnix::InternalDuplicateHandle(
     /* Check validity of process handles */
     if (0 == source_process_id || 0 == target_process_id)
     {
-        ASSERT("Can't duplicate handle: invalid source or destination process");
+        fprintf(stderr, "Can't duplicate handle: invalid source or destination process");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
@@ -122,7 +122,7 @@ CorUnix::InternalDuplicateHandle(
     if (source_process_id != cur_process_id
         && target_process_id != cur_process_id)
     {
-        ASSERT("Can't duplicate handle : neither source or destination"
+        fprintf(stderr, "Can't duplicate handle : neither source or destination"
                "processes are from current process");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
@@ -130,14 +130,14 @@ CorUnix::InternalDuplicateHandle(
 
     if (FALSE != bInheritHandle)
     {
-        ASSERT("Can't duplicate handle : bInheritHandle is not FALSE.\n");
+        fprintf(stderr, "Can't duplicate handle : bInheritHandle is not FALSE.\n");
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
 
     if (dwOptions & ~(DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE))
     {
-        ASSERT(
+        fprintf(stderr,
             "Can't duplicate handle : dwOptions is %#x which is not "
             "a subset of (DUPLICATE_SAME_ACCESS|DUPLICATE_CLOSE_SOURCE) "
             "(%#x).\n",
@@ -149,7 +149,7 @@ CorUnix::InternalDuplicateHandle(
     
     if (0 == (dwOptions & DUPLICATE_SAME_ACCESS))
     {
-        ASSERT(
+        fprintf(stderr,
             "Can't duplicate handle : dwOptions is %#x which does not "
             "include DUPLICATE_SAME_ACCESS (%#x).\n",
             dwOptions,
@@ -160,7 +160,7 @@ CorUnix::InternalDuplicateHandle(
 
     if (NULL == phDuplicate)
     {
-        ASSERT("Can't duplicate handle : lpTargetHandle is NULL.\n");
+        fprintf(stderr, "Can't duplicate handle : lpTargetHandle is NULL.\n");
         goto InternalDuplicateHandleExit;
     }
 
@@ -215,7 +215,7 @@ CorUnix::InternalDuplicateHandle(
     }
     else
     {
-        ASSERT("Duplication not supported for this special handle (%p)\n", hSource);
+        fprintf(stderr, "Duplication not supported for this special handle (%p)\n", hSource);
         palError = ERROR_INVALID_HANDLE;
         goto InternalDuplicateHandleExit;
     }

--- a/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
@@ -24,6 +24,7 @@ Abstract:
 #include "pal/cs.hpp"
 #include <new>
 #include "pal/dbgmsg.h"
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -275,7 +276,7 @@ bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
     
     if (NULL == m_rghteHandleTable)
     {
-        fprintf(stderr, "Handle Manager is not initialized!\n");
+        chakra::Logger::error("Handle Manager is not initialized!\n");
         return FALSE;
     }
     

--- a/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
@@ -25,6 +25,7 @@ Abstract:
 #include <new>
 #include "pal/dbgmsg.h"
 #include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -225,7 +226,7 @@ CSimpleHandleManager::FreeHandle(
 
     if (HandleIsSpecial(h))
     {
-        fprintf(stderr, "Trying to free Special Handle %p.\n", h);
+        chakra::Logger::error(std::format("Trying to free Special Handle {}.\n", h));
         palError = ERROR_INVALID_HANDLE;
         goto FreeHandleExit;
     }
@@ -296,7 +297,7 @@ bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
         // the specialness of the handle) so we assert here.
         //
         
-        fprintf(stderr, "Handle %p is a special handle, returning FALSE.\n", handle);
+        chakra::Logger::error(std::format("Handle {} is a special handle, returning FALSE.\n", handle));
         return FALSE;
     }
 

--- a/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
+++ b/chakracore-cxx/pal/src/handlemgr/handlemgr.cpp
@@ -224,7 +224,7 @@ CSimpleHandleManager::FreeHandle(
 
     if (HandleIsSpecial(h))
     {
-        ASSERT("Trying to free Special Handle %p.\n", h);
+        fprintf(stderr, "Trying to free Special Handle %p.\n", h);
         palError = ERROR_INVALID_HANDLE;
         goto FreeHandleExit;
     }
@@ -275,7 +275,7 @@ bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
     
     if (NULL == m_rghteHandleTable)
     {
-        ASSERT("Handle Manager is not initialized!\n");
+        fprintf(stderr, "Handle Manager is not initialized!\n");
         return FALSE;
     }
     
@@ -295,7 +295,7 @@ bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
         // the specialness of the handle) so we assert here.
         //
         
-        ASSERT ("Handle %p is a special handle, returning FALSE.\n", handle);
+        fprintf(stderr, "Handle %p is a special handle, returning FALSE.\n", handle);
         return FALSE;
     }
 

--- a/chakracore-cxx/pal/src/include/pal/dbgmsg.h
+++ b/chakracore-cxx/pal/src/include/pal/dbgmsg.h
@@ -248,12 +248,7 @@ extern const char16_t* W16_NULLSTRING;
 
 #else /* defined(_DEBUG) */
 
-#define ASSERT(...) \
-{ \
-    PRINT_ERROR("] %s %s:%d",__FUNCTION__,__FILE__,\
-                   __LINE__);\
-    PRINT_ERROR(__VA_ARGS__);\
-}
+#define ASSERT(...) fprintf(stderr, __VA_ARGS__);
 
 #define _ASSERT assert
 #define _ASSERT_MSG(expr, args...) \

--- a/chakracore-cxx/pal/src/include/pal/dbgmsg.h
+++ b/chakracore-cxx/pal/src/include/pal/dbgmsg.h
@@ -248,13 +248,7 @@ extern const char16_t* W16_NULLSTRING;
 #else /* defined(_DEBUG) */
 
 #define _ASSERT assert
-#define _ASSERT_MSG(expr, args...) \
-    do { \
-        if (!(expr)) \
-        { \
-            fprintf(stderr, "Expression: " #expr ", Description: " args); \
-        } \
-    } while(0)
+#define _ASSERT_MSG(expr, args...) assert(expr)
 
 #endif /* defined(_DEBUG) */
 

--- a/chakracore-cxx/pal/src/include/pal/dbgmsg.h
+++ b/chakracore-cxx/pal/src/include/pal/dbgmsg.h
@@ -242,20 +242,17 @@ extern const char16_t* W16_NULLSTRING;
 
 #if !defined(_DEBUG)
 
-#define ASSERT(args...)
 #define _ASSERT(expr)
 #define _ASSERT_MSG(args...)
 
 #else /* defined(_DEBUG) */
-
-#define ASSERT(...) fprintf(stderr, __VA_ARGS__);
 
 #define _ASSERT assert
 #define _ASSERT_MSG(expr, args...) \
     do { \
         if (!(expr)) \
         { \
-            ASSERT("Expression: " #expr ", Description: " args); \
+            fprintf(stderr, "Expression: " #expr ", Description: " args); \
         } \
     } while(0)
 

--- a/chakracore-cxx/pal/src/include/pal/synchcache.hpp
+++ b/chakracore-cxx/pal/src/include/pal/synchcache.hpp
@@ -25,6 +25,8 @@ Abstract:
 #include "pal/thread.hpp"
 #include <new>
 
+#include "chakra/Logger.h"
+
 namespace CorUnix
 {    
     template <typename T> class CSynchCache
@@ -109,7 +111,7 @@ namespace CorUnix
                 // which causes template instatiation in the header
                 // where the DEBUG CHANNEL is not defined and cannot
                 // be defined
-                fprintf(stderr,"SYNCCACHE: Invalid cache depth value");
+                chakra::Logger::error("SYNCCACHE: Invalid cache depth value");
                 DebugBreak();
             }
 #endif // _DEBUG
@@ -283,7 +285,7 @@ namespace CorUnix
             {
                     // Can't use ASSERT here, since this is header
                     // (see comment above)
-                    fprintf(stderr,"SYNCCACHE: Invalid cache depth value");
+                    chakra::Logger::error("SYNCCACHE: Invalid cache depth value");
                     DebugBreak();
             }
 #endif // _DEBUG

--- a/chakracore-cxx/pal/src/init/pal.cpp
+++ b/chakracore-cxx/pal/src/init/pal.cpp
@@ -40,6 +40,7 @@ Abstract:
 #include "pal/locale.h"
 #include "pal/init.h"
 #include "chakra/Logger.h"
+#include <format>
 
 #if defined(__APPLE__)
 #include "../exception/machexception.h"
@@ -177,9 +178,9 @@ Initialize()
         // different, we can't run.
         if (VIRTUAL_PAGE_SIZE != getpagesize())
         {
-            chakra::Logger::error("VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
+            chakra::Logger::error(std::format("VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
                 "Change include/pal/virtual.h and clr/src/inc/stdmacros.h "
-                "to reflect the correct page size of %d.\n", getpagesize());
+                "to reflect the correct page size of {}.\n", getpagesize()));
         }
 #endif  // _DEBUG
 

--- a/chakracore-cxx/pal/src/init/pal.cpp
+++ b/chakracore-cxx/pal/src/init/pal.cpp
@@ -176,7 +176,7 @@ Initialize()
         // different, we can't run.
         if (VIRTUAL_PAGE_SIZE != getpagesize())
         {
-            ASSERT("VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
+            fprintf(stderr, "VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
                 "Change include/pal/virtual.h and clr/src/inc/stdmacros.h "
                 "to reflect the correct page size of %d.\n", getpagesize());
         }
@@ -364,7 +364,7 @@ done:
 
     if (retval != 0 && GetLastError() == ERROR_SUCCESS)
     {
-        ASSERT("returning failure, but last error not set\n");
+        fprintf(stderr, "returning failure, but last error not set\n");
     }
 
     LOGEXIT("PAL_Initialize returns int %d\n", retval);

--- a/chakracore-cxx/pal/src/init/pal.cpp
+++ b/chakracore-cxx/pal/src/init/pal.cpp
@@ -39,6 +39,7 @@ Abstract:
 #include "pal/debug.h"
 #include "pal/locale.h"
 #include "pal/init.h"
+#include "chakra/Logger.h"
 
 #if defined(__APPLE__)
 #include "../exception/machexception.h"
@@ -176,7 +177,7 @@ Initialize()
         // different, we can't run.
         if (VIRTUAL_PAGE_SIZE != getpagesize())
         {
-            fprintf(stderr, "VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
+            chakra::Logger::error("VIRTUAL_PAGE_SIZE is incorrect for this system!\n"
                 "Change include/pal/virtual.h and clr/src/inc/stdmacros.h "
                 "to reflect the correct page size of %d.\n", getpagesize());
         }
@@ -364,7 +365,7 @@ done:
 
     if (retval != 0 && GetLastError() == ERROR_SUCCESS)
     {
-        fprintf(stderr, "returning failure, but last error not set\n");
+        chakra::Logger::error("returning failure, but last error not set\n");
     }
 
     LOGEXIT("PAL_Initialize returns int %d\n", retval);

--- a/chakracore-cxx/pal/src/init/sxs.cpp
+++ b/chakracore-cxx/pal/src/init/sxs.cpp
@@ -17,6 +17,8 @@
 #include "pal/dbgmsg.h"
 #include "pal/thread.hpp"
 #include "../thread/procprivate.hpp"
+#include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -49,7 +51,7 @@ CreateCurrentThreadData()
         PAL_ERROR palError = AllocatePalThread(&pThread);
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Unable to allocate pal thread: error %d - aborting\n", palError);
+            chakra::Logger::error(std::format("Unable to allocate pal thread: error {} - aborting\n", palError));
             abort();
         }
     }

--- a/chakracore-cxx/pal/src/init/sxs.cpp
+++ b/chakracore-cxx/pal/src/init/sxs.cpp
@@ -49,7 +49,7 @@ CreateCurrentThreadData()
         PAL_ERROR palError = AllocatePalThread(&pThread);
         if (NO_ERROR != palError)
         {
-            ASSERT("Unable to allocate pal thread: error %d - aborting\n", palError);
+            fprintf(stderr, "Unable to allocate pal thread: error %d - aborting\n", palError);
             abort();
         }
     }

--- a/chakracore-cxx/pal/src/locale/unicode.cpp
+++ b/chakracore-cxx/pal/src/locale/unicode.cpp
@@ -368,7 +368,7 @@ MultiByteToWideChar(
 
     if (dwFlags & ~(MB_ERR_INVALID_CHARS | MB_PRECOMPOSED))
     {
-        ASSERT("Error dwFlags(0x%x) parameter is invalid\n", dwFlags);
+        fprintf(stderr, "Error dwFlags(0x%x) parameter is invalid\n", dwFlags);
         SetLastError(ERROR_INVALID_FLAGS);
         goto EXIT;
     }

--- a/chakracore-cxx/pal/src/locale/unicode.cpp
+++ b/chakracore-cxx/pal/src/locale/unicode.cpp
@@ -32,6 +32,8 @@ Revision History:
 #include "pal/locale.h"
 #include "pal/cruntime.h"
 #include "pal/stackstring.hpp"
+#include "chakra/Logger.h"
+#include <format>
 
 #include <pthread.h>
 #include <locale.h>
@@ -368,7 +370,7 @@ MultiByteToWideChar(
 
     if (dwFlags & ~(MB_ERR_INVALID_CHARS | MB_PRECOMPOSED))
     {
-        fprintf(stderr, "Error dwFlags(0x%x) parameter is invalid\n", dwFlags);
+        chakra::Logger::error(std::format("Error dwFlags(0x{:x}) parameter is invalid\n", dwFlags));
         SetLastError(ERROR_INVALID_FLAGS);
         goto EXIT;
     }

--- a/chakracore-cxx/pal/src/map/map.cpp
+++ b/chakracore-cxx/pal/src/map/map.cpp
@@ -29,6 +29,7 @@ Abstract:
 #include "pal/map.hpp"
 #include "pal/thread.hpp"
 #include "pal/file.hpp"
+#include "chakra/Logger.h"
 #include <new>
 
 #include <sys/stat.h>
@@ -130,7 +131,7 @@ FileMappingCleanupRoutine(
 
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Unable to obtain immutable data for object to be reclaimed");
+            chakra::Logger::error("Unable to obtain immutable data for object to be reclaimed");
             return;
         }
 
@@ -156,7 +157,7 @@ FileMappingCleanupRoutine(
 
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Unable to obtain process local data for object to be reclaimed");
+            chakra::Logger::error("Unable to obtain process local data for object to be reclaimed");
             return;
         }
 
@@ -290,14 +291,14 @@ CorUnix::InternalCreateFileMapping(
 
     if (lpName != nullptr)
     {
-        fprintf(stderr, "lpName: Cross-process named objects are not supported in PAL");
+        chakra::Logger::error("lpName: Cross-process named objects are not supported in PAL");
         palError = ERROR_NOT_SUPPORTED;
         goto ExitInternalCreateFileMapping;
     }
 
     if (0 != dwMaximumSizeHigh)
     {
-        fprintf(stderr, "dwMaximumSizeHigh is always 0.\n");
+        chakra::Logger::error("dwMaximumSizeHigh is always 0.\n");
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
@@ -322,7 +323,7 @@ CorUnix::InternalCreateFileMapping(
 
     if (hFile != INVALID_HANDLE_VALUE && NULL != lpName)
     {
-        fprintf(stderr, "If hFile is not -1, then lpName must be NULL.\n" );
+        chakra::Logger::error("If hFile is not -1, then lpName must be NULL.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
@@ -471,7 +472,7 @@ CorUnix::InternalCreateFileMapping(
         } 
         else 
         {
-            fprintf(stderr, "should not get here\n");
+            chakra::Logger::error("should not get here\n");
             palError = ERROR_INTERNAL_ERROR;
             goto ExitInternalCreateFileMapping;
         }
@@ -623,7 +624,7 @@ CorUnix::InternalOpenFileMapping(
 
     if ( MAPContainsInvalidFlags( dwDesiredAccess ) ) 
     {
-        fprintf(stderr, "dwDesiredAccess can be one or more of FILE_MAP_READ, "
+        chakra::Logger::error("dwDesiredAccess can be one or more of FILE_MAP_READ, "
                "FILE_MAP_WRITE, FILE_MAP_COPY or FILE_MAP_ALL_ACCESS.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalOpenFileMapping;
@@ -774,7 +775,7 @@ CorUnix::InternalMapViewOfFile(
     /* Sanity checks */
     if ( MAPContainsInvalidFlags( dwDesiredAccess ) )
     {
-        fprintf(stderr, "dwDesiredAccess can be one of FILE_MAP_WRITE, FILE_MAP_READ,"
+        chakra::Logger::error("dwDesiredAccess can be one of FILE_MAP_WRITE, FILE_MAP_READ,"
                " FILE_MAP_COPY or FILE_MAP_ALL_ACCESS.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto InternalMapViewOfFileExit;
@@ -782,7 +783,7 @@ CorUnix::InternalMapViewOfFile(
 
     if ( 0 != dwFileOffsetHigh || 0 != dwFileOffsetLow )
     {
-        fprintf(stderr, "dwFileOffsetHigh and dwFileOffsetLow are always 0.\n" );
+        chakra::Logger::error("dwFileOffsetHigh and dwFileOffsetLow are always 0.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto InternalMapViewOfFileExit;
     }
@@ -889,7 +890,7 @@ CorUnix::InternalMapViewOfFile(
         }
         else
         {
-            fprintf(stderr, "MapFileMapToMmapFlags failed!\n" );
+            chakra::Logger::error("MapFileMapToMmapFlags failed!\n" );
             palError = ERROR_INTERNAL_ERROR;
             goto InternalMapViewOfFileLeaveCriticalSection;
         }
@@ -1178,7 +1179,7 @@ static uint32_t MAPConvertProtectToAccess( uint32_t flProtect )
         return FILE_MAP_COPY;
     }
 
-    fprintf(stderr, "Unknown flag for flProtect. This line "
+    chakra::Logger::error("Unknown flag for flProtect. This line "
             "should not have been executed.\n " );
     return static_cast<uint32_t>(-1);
 }
@@ -1211,7 +1212,7 @@ static uint32_t MAPConvertAccessToProtect(uint32_t flAccess)
         return PAGE_NOACCESS;
     }
 
-    fprintf(stderr, "Unknown flag for flAccess.\n");
+    chakra::Logger::error("Unknown flag for flAccess.\n");
     return static_cast<uint32_t>(-1);
 }
 
@@ -1248,7 +1249,7 @@ static int32_t MAPFileMapToMmapFlags( uint32_t flags )
         return PROT_READ | PROT_WRITE;
     } 
 
-    fprintf(stderr, "Unknown flag. This line should not have been executed.\n" );
+    chakra::Logger::error("Unknown flag. This line should not have been executed.\n" );
     return -1;
 }
 

--- a/chakracore-cxx/pal/src/map/map.cpp
+++ b/chakracore-cxx/pal/src/map/map.cpp
@@ -130,7 +130,7 @@ FileMappingCleanupRoutine(
 
         if (NO_ERROR != palError)
         {
-            ASSERT("Unable to obtain immutable data for object to be reclaimed");
+            fprintf(stderr, "Unable to obtain immutable data for object to be reclaimed");
             return;
         }
 
@@ -156,7 +156,7 @@ FileMappingCleanupRoutine(
 
         if (NO_ERROR != palError)
         {
-            ASSERT("Unable to obtain process local data for object to be reclaimed");
+            fprintf(stderr, "Unable to obtain process local data for object to be reclaimed");
             return;
         }
 
@@ -290,14 +290,14 @@ CorUnix::InternalCreateFileMapping(
 
     if (lpName != nullptr)
     {
-        ASSERT("lpName: Cross-process named objects are not supported in PAL");
+        fprintf(stderr, "lpName: Cross-process named objects are not supported in PAL");
         palError = ERROR_NOT_SUPPORTED;
         goto ExitInternalCreateFileMapping;
     }
 
     if (0 != dwMaximumSizeHigh)
     {
-        ASSERT("dwMaximumSizeHigh is always 0.\n");
+        fprintf(stderr, "dwMaximumSizeHigh is always 0.\n");
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
@@ -306,7 +306,7 @@ CorUnix::InternalCreateFileMapping(
         && PAGE_READONLY != flProtect
         && PAGE_WRITECOPY != flProtect)
     {
-        ASSERT( "invalid flProtect %#x, acceptable values are PAGE_READONLY "
+        fprintf(stderr, "invalid flProtect %#x, acceptable values are PAGE_READONLY "
                 "(%#x), PAGE_READWRITE (%#x) and PAGE_WRITECOPY (%#x).\n", 
                 flProtect, PAGE_READONLY, PAGE_READWRITE, PAGE_WRITECOPY );
         palError = ERROR_INVALID_PARAMETER;
@@ -322,7 +322,7 @@ CorUnix::InternalCreateFileMapping(
 
     if (hFile != INVALID_HANDLE_VALUE && NULL != lpName)
     {
-        ASSERT( "If hFile is not -1, then lpName must be NULL.\n" );
+        fprintf(stderr, "If hFile is not -1, then lpName must be NULL.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
@@ -471,14 +471,14 @@ CorUnix::InternalCreateFileMapping(
         } 
         else 
         {
-            ASSERT("should not get here\n");
+            fprintf(stderr, "should not get here\n");
             palError = ERROR_INTERNAL_ERROR;
             goto ExitInternalCreateFileMapping;
         }
     
         if (-1 == fstat(UnixFd, &UnixFileInformation))
         {
-            ASSERT("fstat() failed for this reason %s.\n", strerror(errno));
+            fprintf(stderr, "fstat() failed for this reason %s.\n", strerror(errno));
             palError = ERROR_INTERNAL_ERROR;
             goto ExitInternalCreateFileMapping;
         }
@@ -623,7 +623,7 @@ CorUnix::InternalOpenFileMapping(
 
     if ( MAPContainsInvalidFlags( dwDesiredAccess ) ) 
     {
-        ASSERT( "dwDesiredAccess can be one or more of FILE_MAP_READ, " 
+        fprintf(stderr, "dwDesiredAccess can be one or more of FILE_MAP_READ, "
                "FILE_MAP_WRITE, FILE_MAP_COPY or FILE_MAP_ALL_ACCESS.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalOpenFileMapping;
@@ -774,7 +774,7 @@ CorUnix::InternalMapViewOfFile(
     /* Sanity checks */
     if ( MAPContainsInvalidFlags( dwDesiredAccess ) )
     {
-        ASSERT( "dwDesiredAccess can be one of FILE_MAP_WRITE, FILE_MAP_READ,"
+        fprintf(stderr, "dwDesiredAccess can be one of FILE_MAP_WRITE, FILE_MAP_READ,"
                " FILE_MAP_COPY or FILE_MAP_ALL_ACCESS.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto InternalMapViewOfFileExit;
@@ -782,7 +782,7 @@ CorUnix::InternalMapViewOfFile(
 
     if ( 0 != dwFileOffsetHigh || 0 != dwFileOffsetLow )
     {
-        ASSERT( "dwFileOffsetHigh and dwFileOffsetLow are always 0.\n" );
+        fprintf(stderr, "dwFileOffsetHigh and dwFileOffsetLow are always 0.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto InternalMapViewOfFileExit;
     }
@@ -889,7 +889,7 @@ CorUnix::InternalMapViewOfFile(
         }
         else
         {
-            ASSERT( "MapFileMapToMmapFlags failed!\n" );
+            fprintf(stderr, "MapFileMapToMmapFlags failed!\n" );
             palError = ERROR_INTERNAL_ERROR;
             goto InternalMapViewOfFileLeaveCriticalSection;
         }
@@ -982,7 +982,7 @@ CorUnix::InternalUnmapViewOfFile(
     
     if (-1 == munmap(const_cast<void*>(lpBaseAddress), pView->NumberOfBytesToMap))
     {
-        ASSERT( "Unable to unmap the memory. Error=%s.\n",
+        fprintf(stderr, "Unable to unmap the memory. Error=%s.\n",
                 strerror( errno ) );
         palError = ERROR_INTERNAL_ERROR;
 
@@ -1178,7 +1178,7 @@ static uint32_t MAPConvertProtectToAccess( uint32_t flProtect )
         return FILE_MAP_COPY;
     }
 
-    ASSERT( "Unknown flag for flProtect. This line "
+    fprintf(stderr, "Unknown flag for flProtect. This line "
             "should not have been executed.\n " );
     return static_cast<uint32_t>(-1);
 }
@@ -1211,7 +1211,7 @@ static uint32_t MAPConvertAccessToProtect(uint32_t flAccess)
         return PAGE_NOACCESS;
     }
 
-    ASSERT("Unknown flag for flAccess.\n");
+    fprintf(stderr, "Unknown flag for flAccess.\n");
     return static_cast<uint32_t>(-1);
 }
 
@@ -1248,7 +1248,7 @@ static int32_t MAPFileMapToMmapFlags( uint32_t flags )
         return PROT_READ | PROT_WRITE;
     } 
 
-    ASSERT( "Unknown flag. This line should not have been executed.\n" );
+    fprintf(stderr, "Unknown flag. This line should not have been executed.\n" );
     return -1;
 }
 
@@ -1394,7 +1394,7 @@ static int32_t MAPProtectionToFileOpenFlags( uint32_t flProtect )
         retVal = O_RDONLY;
         break;
     default:
-        ASSERT("unexpected flProtect value %#x\n", flProtect);
+        fprintf(stderr, "unexpected flProtect value %#x\n", flProtect);
         retVal = 0;
         break;
     }         

--- a/chakracore-cxx/pal/src/map/map.cpp
+++ b/chakracore-cxx/pal/src/map/map.cpp
@@ -37,6 +37,7 @@ Abstract:
 #include <sys/mman.h>
 #include <unistd.h>
 #include <errno.h>
+#include <format>
 
 using namespace CorUnix;
 
@@ -307,9 +308,9 @@ CorUnix::InternalCreateFileMapping(
         && PAGE_READONLY != flProtect
         && PAGE_WRITECOPY != flProtect)
     {
-        fprintf(stderr, "invalid flProtect %#x, acceptable values are PAGE_READONLY "
-                "(%#x), PAGE_READWRITE (%#x) and PAGE_WRITECOPY (%#x).\n", 
-                flProtect, PAGE_READONLY, PAGE_READWRITE, PAGE_WRITECOPY );
+        chakra::Logger::error(std::format("invalid flProtect {:#x}, acceptable values are PAGE_READONLY "
+                "({:#x}), PAGE_READWRITE ({:#x}) and PAGE_WRITECOPY ({:#x}).\n",
+                flProtect, PAGE_READONLY, PAGE_READWRITE, PAGE_WRITECOPY ));
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
@@ -479,7 +480,7 @@ CorUnix::InternalCreateFileMapping(
     
         if (-1 == fstat(UnixFd, &UnixFileInformation))
         {
-            fprintf(stderr, "fstat() failed for this reason %s.\n", strerror(errno));
+            chakra::Logger::error(std::format("fstat() failed for this reason {}.\n", strerror(errno)));
             palError = ERROR_INTERNAL_ERROR;
             goto ExitInternalCreateFileMapping;
         }
@@ -983,8 +984,8 @@ CorUnix::InternalUnmapViewOfFile(
     
     if (-1 == munmap(const_cast<void*>(lpBaseAddress), pView->NumberOfBytesToMap))
     {
-        fprintf(stderr, "Unable to unmap the memory. Error=%s.\n",
-                strerror( errno ) );
+        chakra::Logger::error(std::format("Unable to unmap the memory. Error={}.\n",
+                strerror( errno ) ));
         palError = ERROR_INTERNAL_ERROR;
 
         //
@@ -1395,7 +1396,7 @@ static int32_t MAPProtectionToFileOpenFlags( uint32_t flProtect )
         retVal = O_RDONLY;
         break;
     default:
-        fprintf(stderr, "unexpected flProtect value %#x\n", flProtect);
+        chakra::Logger::error(std::format("unexpected flProtect value {:#x}\n", flProtect));
         retVal = 0;
         break;
     }         

--- a/chakracore-cxx/pal/src/map/virtual.cpp
+++ b/chakracore-cxx/pal/src/map/virtual.cpp
@@ -28,6 +28,7 @@ Abstract:
 #include "pal/map.h"
 #include "pal/init.h"
 #include "common.h"
+#include "chakra/Logger.h"
 
 #include <sys/types.h>
 #include <sys/mman.h>
@@ -484,7 +485,7 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
 
     if ( !pMemoryToBeReleased )
     {
-        fprintf(stderr, "Invalid pointer.\n" );
+        chakra::Logger::error("Invalid pointer.\n" );
         return FALSE;
     }
 
@@ -851,7 +852,7 @@ static void * VIRTUALReserveMemory(
         if ( !VIRTUALStoreAllocationInfo( StartBoundary, MemSize,
                                    flAllocationType, flProtect ) )
         {
-            fprintf(stderr, "Unable to store the structure in the list.\n");
+            chakra::Logger::error("Unable to store the structure in the list.\n");
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             munmap( pRetVal, MemSize );
             pRetVal = NULL;
@@ -1011,7 +1012,7 @@ static void * VIRTUALCommitMemory(
 
             if ( !pInformation )
             {
-                fprintf(stderr, "Unable to locate the region information.\n" );
+                chakra::Logger::error("Unable to locate the region information.\n" );
                 pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
                 pRetVal = NULL;
                 goto done;
@@ -1131,7 +1132,7 @@ error:
         munmap( pRetVal, MemSize );
         if ( VIRTUALReleaseMemory( pInformation ) == FALSE )
         {
-            fprintf(stderr, "Unable to remove the PCMI entry from the list.\n" );
+            chakra::Logger::error("Unable to remove the PCMI entry from the list.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             pRetVal = NULL;
             goto done;
@@ -1176,7 +1177,7 @@ static BOOL VIRTUALGetBackingFile(CPalThread *pthrCurrent)
 
     if (!(PALGetLibRotorPalName(palName, MAX_PATH_FNAME)))
     {
-        fprintf(stderr, "Surprisingly, LibRotorPal can't be found!");
+        chakra::Logger::error("Surprisingly, LibRotorPal can't be found!");
         goto done;
     }
     gBackingFile = InternalOpen(palName, O_RDONLY);
@@ -1226,14 +1227,14 @@ VirtualAlloc_(
     /* Test for un-supported flags. */
     if ( ( flAllocationType & ~( MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN | MEM_RESERVE_EXECUTABLE ) ) != 0 )
     {
-        fprintf(stderr, "flAllocationType can be one, or any combination of MEM_COMMIT, \
+        chakra::Logger::error("flAllocationType can be one, or any combination of MEM_COMMIT, \
                MEM_RESERVE, MEM_TOP_DOWN, or MEM_RESERVE_EXECUTABLE.\n" );
         pthrCurrent->SetLastError( ERROR_INVALID_PARAMETER );
         goto done;
     }
     if ( VIRTUALContainsInvalidProtectionFlags( flProtect ) )
     {
-        fprintf(stderr, "flProtect can be one of PAGE_READONLY, PAGE_READWRITE, or \
+        chakra::Logger::error("flProtect can be one of PAGE_READONLY, PAGE_READWRITE, or \
                PAGE_EXECUTE_READWRITE || PAGE_NOACCESS. \n" );
 
         pthrCurrent->SetLastError( ERROR_INVALID_PARAMETER );
@@ -1352,7 +1353,7 @@ VirtualFreeEnclosing_(
     }
     else
     {
-        fprintf(stderr, "Unable to unmap the memory, munmap() returned "
+        chakra::Logger::error("Unable to unmap the memory, munmap() returned "
             "an abnormal value.\n");
         pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
         bRetVal = FALSE;
@@ -1368,7 +1369,7 @@ VirtualFreeEnclosing_(
         }
         else
         {
-            fprintf(stderr, "Unable to unmap the memory, munmap() returned "
+            chakra::Logger::error("Unable to unmap the memory, munmap() returned "
                 "an abnormal value.\n");
             pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
             bRetVal = FALSE;
@@ -1439,7 +1440,7 @@ VirtualAlloc(
             // Free the regions enclosing the 64K aligned region we intend to use.
             if (VirtualFreeEnclosing_(address, dwSize, KB64, addr64) == 0)
             {
-                fprintf(stderr, "Unable to unmap the enclosing memory.\n");
+                chakra::Logger::error("Unable to unmap the enclosing memory.\n");
                 return nullptr;
             }
 
@@ -1538,7 +1539,7 @@ VirtualFree(
         pUnCommittedMem = VIRTUALFindRegionInformation( StartBoundary );
         if (!pUnCommittedMem)
         {
-            fprintf(stderr, "Unable to locate the region information.\n" );
+            chakra::Logger::error("Unable to locate the region information.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             bRetVal = FALSE;
             goto VirtualFreeExit;
@@ -1573,7 +1574,7 @@ VirtualFree(
         }
         else
         {
-            fprintf(stderr, "mmap() returned an abnormal value.\n" );
+            chakra::Logger::error("mmap() returned an abnormal value.\n" );
             bRetVal = FALSE;
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             goto VirtualFreeExit;
@@ -1608,7 +1609,7 @@ VirtualFree(
         {
             if ( VIRTUALReleaseMemory( pMemoryToBeReleased ) == FALSE )
             {
-                fprintf(stderr, "Unable to remove the PCMI entry from the list.\n" );
+                chakra::Logger::error("Unable to remove the PCMI entry from the list.\n" );
                 pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
                 bRetVal = FALSE;
                 goto VirtualFreeExit;
@@ -1617,7 +1618,7 @@ VirtualFree(
         }
         else
         {
-            fprintf(stderr, "Unable to unmap the memory, munmap() returned "
+            chakra::Logger::error("Unable to unmap the memory, munmap() returned "
                    "an abnormal value.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             bRetVal = FALSE;
@@ -1663,7 +1664,7 @@ VirtualProtect(
 #if DEBUG
     if ( VIRTUALContainsInvalidProtectionFlags( flNewProtect ) )
     {
-        fprintf(stderr, "flProtect can be one of PAGE_NOACCESS, PAGE_READONLY, "
+        chakra::Logger::error("flProtect can be one of PAGE_NOACCESS, PAGE_READONLY, "
                "PAGE_READWRITE, PAGE_EXECUTE, PAGE_EXECUTE_READ "
                ", or PAGE_EXECUTE_READWRITE. \n" );
         SetLastError( ERROR_INVALID_PARAMETER );

--- a/chakracore-cxx/pal/src/map/virtual.cpp
+++ b/chakracore-cxx/pal/src/map/virtual.cpp
@@ -484,7 +484,7 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
 
     if ( !pMemoryToBeReleased )
     {
-        ASSERT( "Invalid pointer.\n" );
+        fprintf(stderr, "Invalid pointer.\n" );
         return FALSE;
     }
 
@@ -851,7 +851,7 @@ static void * VIRTUALReserveMemory(
         if ( !VIRTUALStoreAllocationInfo( StartBoundary, MemSize,
                                    flAllocationType, flProtect ) )
         {
-            ASSERT( "Unable to store the structure in the list.\n");
+            fprintf(stderr, "Unable to store the structure in the list.\n");
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             munmap( pRetVal, MemSize );
             pRetVal = NULL;
@@ -1011,7 +1011,7 @@ static void * VIRTUALCommitMemory(
 
             if ( !pInformation )
             {
-                ASSERT( "Unable to locate the region information.\n" );
+                fprintf(stderr, "Unable to locate the region information.\n" );
                 pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
                 pRetVal = NULL;
                 goto done;
@@ -1131,7 +1131,7 @@ error:
         munmap( pRetVal, MemSize );
         if ( VIRTUALReleaseMemory( pInformation ) == FALSE )
         {
-            ASSERT( "Unable to remove the PCMI entry from the list.\n" );
+            fprintf(stderr, "Unable to remove the PCMI entry from the list.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             pRetVal = NULL;
             goto done;
@@ -1176,13 +1176,13 @@ static BOOL VIRTUALGetBackingFile(CPalThread *pthrCurrent)
 
     if (!(PALGetLibRotorPalName(palName, MAX_PATH_FNAME)))
     {
-        ASSERT("Surprisingly, LibRotorPal can't be found!");
+        fprintf(stderr, "Surprisingly, LibRotorPal can't be found!");
         goto done;
     }
     gBackingFile = InternalOpen(palName, O_RDONLY);
     if (gBackingFile == -1)
     {
-        ASSERT("Failed to open %s as a backing file: errno=%d\n",
+        fprintf(stderr, "Failed to open %s as a backing file: errno=%d\n",
                 palName, errno);
         goto done;
     }
@@ -1226,14 +1226,14 @@ VirtualAlloc_(
     /* Test for un-supported flags. */
     if ( ( flAllocationType & ~( MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN | MEM_RESERVE_EXECUTABLE ) ) != 0 )
     {
-        ASSERT( "flAllocationType can be one, or any combination of MEM_COMMIT, \
+        fprintf(stderr, "flAllocationType can be one, or any combination of MEM_COMMIT, \
                MEM_RESERVE, MEM_TOP_DOWN, or MEM_RESERVE_EXECUTABLE.\n" );
         pthrCurrent->SetLastError( ERROR_INVALID_PARAMETER );
         goto done;
     }
     if ( VIRTUALContainsInvalidProtectionFlags( flProtect ) )
     {
-        ASSERT( "flProtect can be one of PAGE_READONLY, PAGE_READWRITE, or \
+        fprintf(stderr, "flProtect can be one of PAGE_READONLY, PAGE_READWRITE, or \
                PAGE_EXECUTE_READWRITE || PAGE_NOACCESS. \n" );
 
         pthrCurrent->SetLastError( ERROR_INVALID_PARAMETER );
@@ -1352,7 +1352,7 @@ VirtualFreeEnclosing_(
     }
     else
     {
-        ASSERT("Unable to unmap the memory, munmap() returned "
+        fprintf(stderr, "Unable to unmap the memory, munmap() returned "
             "an abnormal value.\n");
         pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
         bRetVal = FALSE;
@@ -1368,7 +1368,7 @@ VirtualFreeEnclosing_(
         }
         else
         {
-            ASSERT("Unable to unmap the memory, munmap() returned "
+            fprintf(stderr, "Unable to unmap the memory, munmap() returned "
                 "an abnormal value.\n");
             pthrCurrent->SetLastError(ERROR_INTERNAL_ERROR);
             bRetVal = FALSE;
@@ -1439,7 +1439,7 @@ VirtualAlloc(
             // Free the regions enclosing the 64K aligned region we intend to use.
             if (VirtualFreeEnclosing_(address, dwSize, KB64, addr64) == 0)
             {
-                ASSERT("Unable to unmap the enclosing memory.\n");
+                fprintf(stderr, "Unable to unmap the enclosing memory.\n");
                 return nullptr;
             }
 
@@ -1538,7 +1538,7 @@ VirtualFree(
         pUnCommittedMem = VIRTUALFindRegionInformation( StartBoundary );
         if (!pUnCommittedMem)
         {
-            ASSERT( "Unable to locate the region information.\n" );
+            fprintf(stderr, "Unable to locate the region information.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             bRetVal = FALSE;
             goto VirtualFreeExit;
@@ -1573,7 +1573,7 @@ VirtualFree(
         }
         else
         {
-            ASSERT( "mmap() returned an abnormal value.\n" );
+            fprintf(stderr, "mmap() returned an abnormal value.\n" );
             bRetVal = FALSE;
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             goto VirtualFreeExit;
@@ -1608,7 +1608,7 @@ VirtualFree(
         {
             if ( VIRTUALReleaseMemory( pMemoryToBeReleased ) == FALSE )
             {
-                ASSERT( "Unable to remove the PCMI entry from the list.\n" );
+                fprintf(stderr, "Unable to remove the PCMI entry from the list.\n" );
                 pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
                 bRetVal = FALSE;
                 goto VirtualFreeExit;
@@ -1617,7 +1617,7 @@ VirtualFree(
         }
         else
         {
-            ASSERT( "Unable to unmap the memory, munmap() returned "
+            fprintf(stderr, "Unable to unmap the memory, munmap() returned "
                    "an abnormal value.\n" );
             pthrCurrent->SetLastError( ERROR_INTERNAL_ERROR );
             bRetVal = FALSE;
@@ -1663,7 +1663,7 @@ VirtualProtect(
 #if DEBUG
     if ( VIRTUALContainsInvalidProtectionFlags( flNewProtect ) )
     {
-        ASSERT( "flProtect can be one of PAGE_NOACCESS, PAGE_READONLY, "
+        fprintf(stderr, "flProtect can be one of PAGE_NOACCESS, PAGE_READONLY, "
                "PAGE_READWRITE, PAGE_EXECUTE, PAGE_EXECUTE_READ "
                ", or PAGE_EXECUTE_READWRITE. \n" );
         SetLastError( ERROR_INVALID_PARAMETER );

--- a/chakracore-cxx/pal/src/map/virtual.cpp
+++ b/chakracore-cxx/pal/src/map/virtual.cpp
@@ -1183,8 +1183,8 @@ static BOOL VIRTUALGetBackingFile(CPalThread *pthrCurrent)
     gBackingFile = InternalOpen(palName, O_RDONLY);
     if (gBackingFile == -1)
     {
-        fprintf(stderr, "Failed to open %s as a backing file: errno=%d\n",
-                palName, errno);
+        chakra::Logger::error(std::format("Failed to open {} as a backing file: errno={}\n",
+                palName, errno));
         goto done;
     }
 

--- a/chakracore-cxx/pal/src/map/virtual.cpp
+++ b/chakracore-cxx/pal/src/map/virtual.cpp
@@ -36,6 +36,8 @@ Abstract:
 #include <unistd.h>
 #include <limits.h>
 
+#include "chakra/Logger.h"
+
 #if defined(__APPLE__)
 #include <mach/vm_map.h>
 #include <mach/mach_init.h>
@@ -824,7 +826,7 @@ static void * VIRTUALReserveMemory(
 
     if ((flAllocationType & MEM_RESERVE_EXECUTABLE) != 0)
     {
-        fprintf(stderr, "MEM_RESERVE_EXECUTABLE is not supported!");
+        chakra::Logger::error("MEM_RESERVE_EXECUTABLE is not supported!");
         abort();
     }
 

--- a/chakracore-cxx/pal/src/misc/environ.cpp
+++ b/chakracore-cxx/pal/src/misc/environ.cpp
@@ -25,6 +25,7 @@ Revision History:
 #include "pal/critsect.h"
 #include "pal/dbgmsg.h"
 #include "pal/misc.h"
+#include "chakra/Logger.h"
 
 #include <stdlib.h>
 
@@ -166,7 +167,7 @@ GetEnvironmentVariableW(
     if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpName, -1, inBuff, 
                                    inBuffSize, NULL ) )
     {
-        fprintf(stderr, "WideCharToMultiByte failed!\n" );
+        chakra::Logger::error("WideCharToMultiByte failed!\n" );
         SetLastError( ERROR_INTERNAL_ERROR );
         goto done;
     }
@@ -189,7 +190,7 @@ GetEnvironmentVariableW(
         }
         else
         {
-            fprintf(stderr, "MultiByteToWideChar failed!\n" );
+            chakra::Logger::error("MultiByteToWideChar failed!\n" );
             SetLastError( ERROR_INTERNAL_ERROR );
             size = 0;
             *lpBuffer = '\0';

--- a/chakracore-cxx/pal/src/misc/environ.cpp
+++ b/chakracore-cxx/pal/src/misc/environ.cpp
@@ -166,7 +166,7 @@ GetEnvironmentVariableW(
     if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpName, -1, inBuff, 
                                    inBuffSize, NULL ) )
     {
-        ASSERT( "WideCharToMultiByte failed!\n" );
+        fprintf(stderr, "WideCharToMultiByte failed!\n" );
         SetLastError( ERROR_INTERNAL_ERROR );
         goto done;
     }
@@ -189,7 +189,7 @@ GetEnvironmentVariableW(
         }
         else
         {
-            ASSERT( "MultiByteToWideChar failed!\n" );
+            fprintf(stderr, "MultiByteToWideChar failed!\n" );
             SetLastError( ERROR_INTERNAL_ERROR );
             size = 0;
             *lpBuffer = '\0';

--- a/chakracore-cxx/pal/src/misc/sysinfo.cpp
+++ b/chakracore-cxx/pal/src/misc/sysinfo.cpp
@@ -30,6 +30,8 @@ Revision History:
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include "chakra/Logger.h"
+#include <format>
 
 #include <sys/param.h>
 
@@ -114,7 +116,7 @@ GetSystemInfo(
     nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
     if (nrcpus < 1)
     {
-        fprintf(stderr, "sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
+        chakra::Logger::error(std::format("sysconf failed for _SC_NPROCESSORS_ONLN ({})\n", errno));
     }
 
     TRACE("dwNumberOfProcessors=%d\n", nrcpus);

--- a/chakracore-cxx/pal/src/misc/sysinfo.cpp
+++ b/chakracore-cxx/pal/src/misc/sysinfo.cpp
@@ -114,7 +114,7 @@ GetSystemInfo(
     nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
     if (nrcpus < 1)
     {
-        ASSERT("sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
+        fprintf(stderr, "sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
     }
 
     TRACE("dwNumberOfProcessors=%d\n", nrcpus);

--- a/chakracore-cxx/pal/src/misc/time.cpp
+++ b/chakracore-cxx/pal/src/misc/time.cpp
@@ -59,7 +59,7 @@ BOOL TIMEInitialize(void)
     kern_return_t machRet;
     if ((machRet = mach_timebase_info(&s_TimebaseInfo)) != KERN_SUCCESS)
     {
-        ASSERT("mach_timebase_info() failed: %s\n", mach_error_string(machRet));
+        fprintf(stderr, "mach_timebase_info() failed: %s\n", mach_error_string(machRet));
         return FALSE;
     }
 #endif
@@ -105,7 +105,7 @@ GetSystemTime(
     utPtr = &ut;
     if (gmtime_r(&tt, utPtr) == NULL)
     {
-        ASSERT("gmtime() failed; errno is %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "gmtime() failed; errno is %d (%s)\n", errno, strerror(errno));
         goto EXIT;
     }
 
@@ -119,7 +119,7 @@ GetSystemTime(
 
     if(-1 == timeofday_retval)
     {
-        ASSERT("gettimeofday() failed; errno is %d (%s)\n",
+        fprintf(stderr, "gettimeofday() failed; errno is %d (%s)\n",
                errno, strerror(errno));
         lpSystemTime->wMilliseconds = 0;
     }
@@ -193,7 +193,7 @@ QueryPerformanceCounter(
         struct timespec ts;
         if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
         {
-            ASSERT("clock_gettime(CLOCK_MONOTONIC) failed; errno is %d (%s)\n", errno, strerror(errno));
+            fprintf(stderr, "clock_gettime(CLOCK_MONOTONIC) failed; errno is %d (%s)\n", errno, strerror(errno));
             retval = FALSE;
             break;
         }
@@ -246,7 +246,7 @@ QueryThreadCycleTime(
 
     if(!GetThreadTimesInternal(ThreadHandle, &kernelTime, &userTime))
     {
-        ASSERT("Could not get cycle time for current thread");
+        fprintf(stderr, "Could not get cycle time for current thread");
         retval = FALSE;
         goto EXIT;
     }
@@ -276,7 +276,7 @@ GetTickCount64Fallback()
         struct timespec ts;
         if (clock_gettime(clockType, &ts) != 0)
         {
-            ASSERT("clock_gettime(CLOCK_MONOTONIC*) failed; errno is %d (%s)\n", errno, strerror(errno));
+            fprintf(stderr, "clock_gettime(CLOCK_MONOTONIC*) failed; errno is %d (%s)\n", errno, strerror(errno));
             goto EXIT;
         }
         retval = (ts.tv_sec * tccSecondsToMillieSeconds)+(ts.tv_nsec / tccMillieSecondsToNanoSeconds);
@@ -286,7 +286,7 @@ GetTickCount64Fallback()
         // use denom == 0 to indicate that s_TimebaseInfo is uninitialised.
         if (s_TimebaseInfo.denom == 0)
         {
-            ASSERT("s_TimebaseInfo is uninitialized.\n");
+            fprintf(stderr, "s_TimebaseInfo is uninitialized.\n");
             goto EXIT;
         }
         retval = (mach_absolute_time() * s_TimebaseInfo.numer / s_TimebaseInfo.denom) / tccMillieSecondsToNanoSeconds;

--- a/chakracore-cxx/pal/src/misc/time.cpp
+++ b/chakracore-cxx/pal/src/misc/time.cpp
@@ -25,6 +25,7 @@ Abstract:
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
 #include "pal/misc.h"
+#include "chakra/Logger.h"
 
 #include <time.h>
 #include <sys/time.h>
@@ -246,7 +247,7 @@ QueryThreadCycleTime(
 
     if(!GetThreadTimesInternal(ThreadHandle, &kernelTime, &userTime))
     {
-        fprintf(stderr, "Could not get cycle time for current thread");
+        chakra::Logger::error("Could not get cycle time for current thread");
         retval = FALSE;
         goto EXIT;
     }
@@ -286,7 +287,7 @@ GetTickCount64Fallback()
         // use denom == 0 to indicate that s_TimebaseInfo is uninitialised.
         if (s_TimebaseInfo.denom == 0)
         {
-            fprintf(stderr, "s_TimebaseInfo is uninitialized.\n");
+            chakra::Logger::error("s_TimebaseInfo is uninitialized.\n");
             goto EXIT;
         }
         retval = (mach_absolute_time() * s_TimebaseInfo.numer / s_TimebaseInfo.denom) / tccMillieSecondsToNanoSeconds;

--- a/chakracore-cxx/pal/src/misc/time.cpp
+++ b/chakracore-cxx/pal/src/misc/time.cpp
@@ -32,6 +32,7 @@ Abstract:
 #include <errno.h>
 #include <string.h>
 #include <sched.h>
+#include <format>
 
 #if defined(__APPLE__)
 #include <mach/mach_time.h>
@@ -60,7 +61,7 @@ BOOL TIMEInitialize(void)
     kern_return_t machRet;
     if ((machRet = mach_timebase_info(&s_TimebaseInfo)) != KERN_SUCCESS)
     {
-        fprintf(stderr, "mach_timebase_info() failed: %s\n", mach_error_string(machRet));
+        chakra::Logger::error(std::format("mach_timebase_info() failed: {}\n", mach_error_string(machRet)));
         return FALSE;
     }
 #endif
@@ -106,7 +107,7 @@ GetSystemTime(
     utPtr = &ut;
     if (gmtime_r(&tt, utPtr) == NULL)
     {
-        fprintf(stderr, "gmtime() failed; errno is %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("gmtime() failed; errno is {} ({})\n", errno, strerror(errno)));
         goto EXIT;
     }
 
@@ -120,8 +121,8 @@ GetSystemTime(
 
     if(-1 == timeofday_retval)
     {
-        fprintf(stderr, "gettimeofday() failed; errno is %d (%s)\n",
-               errno, strerror(errno));
+        chakra::Logger::error(std::format("gettimeofday() failed; errno is {} ({})\n",
+               errno, strerror(errno)));
         lpSystemTime->wMilliseconds = 0;
     }
     else
@@ -194,7 +195,7 @@ QueryPerformanceCounter(
         struct timespec ts;
         if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
         {
-            fprintf(stderr, "clock_gettime(CLOCK_MONOTONIC) failed; errno is %d (%s)\n", errno, strerror(errno));
+            chakra::Logger::error(std::format("clock_gettime(CLOCK_MONOTONIC) failed; errno is {} ({})\n", errno, strerror(errno)));
             retval = FALSE;
             break;
         }
@@ -277,7 +278,7 @@ GetTickCount64Fallback()
         struct timespec ts;
         if (clock_gettime(clockType, &ts) != 0)
         {
-            fprintf(stderr, "clock_gettime(CLOCK_MONOTONIC*) failed; errno is %d (%s)\n", errno, strerror(errno));
+            chakra::Logger::error(std::format("clock_gettime(CLOCK_MONOTONIC*) failed; errno is {} ({})\n", errno, strerror(errno)));
             goto EXIT;
         }
         retval = (ts.tv_sec * tccSecondsToMillieSeconds)+(ts.tv_nsec / tccMillieSecondsToNanoSeconds);

--- a/chakracore-cxx/pal/src/misc/utils.cpp
+++ b/chakracore-cxx/pal/src/misc/utils.cpp
@@ -27,6 +27,8 @@ Abstract:
 #include "pal/utils.h"
 #include "pal/dbgmsg.h"
 #include "pal/file.h"
+#include "chakra/Logger.h"
+#include <format>
 
 #include <errno.h>
 #include <string.h>
@@ -198,7 +200,7 @@ char* UTIL_WCToMB_Alloc(const char16_t* lpWideCharStr, int cchWideChar)
                                  lpMultiByteStr, length, NULL);
     if(0 == length)
     {
-        fprintf(stderr, "WCToMB error; GetLastError returns %#x\n", GetLastError());
+        chakra::Logger::error(std::format("WCToMB error; GetLastError returns {:#x}\n", GetLastError()));
         free(lpMultiByteStr);
         return NULL;
     }
@@ -258,7 +260,7 @@ char16_t* UTIL_MBToWC_Alloc(const char * lpMultiByteStr, int cbMultiByte)
                                       lpWideCharStr, length);
     if(0 >= length)
     {
-        fprintf(stderr, "MCToMB error; GetLastError returns %#x\n", GetLastError());
+        chakra::Logger::error(std::format("MCToMB error; GetLastError returns {:#x}\n", GetLastError()));
         free(lpWideCharStr);
         return NULL;
     }
@@ -296,7 +298,7 @@ uint32_t UTIL_MachErrorToPalError(kern_return_t MachReturn)
         return ERROR_INVALID_PARAMETER;
 
     default:
-        fprintf(stderr, "Unknown kern_return_t value %d - reporting ERROR_INTERNAL_ERROR\n", MachReturn);
+        chakra::Logger::error(std::format("Unknown kern_return_t value {} - reporting ERROR_INTERNAL_ERROR\n", MachReturn));
         return ERROR_INTERNAL_ERROR;
     }
 }

--- a/chakracore-cxx/pal/src/misc/utils.cpp
+++ b/chakracore-cxx/pal/src/misc/utils.cpp
@@ -198,7 +198,7 @@ char* UTIL_WCToMB_Alloc(const char16_t* lpWideCharStr, int cchWideChar)
                                  lpMultiByteStr, length, NULL);
     if(0 == length)
     {
-        ASSERT("WCToMB error; GetLastError returns %#x\n", GetLastError());
+        fprintf(stderr, "WCToMB error; GetLastError returns %#x\n", GetLastError());
         free(lpMultiByteStr);
         return NULL;
     }
@@ -258,7 +258,7 @@ char16_t* UTIL_MBToWC_Alloc(const char * lpMultiByteStr, int cbMultiByte)
                                       lpWideCharStr, length);
     if(0 >= length)
     {
-        ASSERT("MCToMB error; GetLastError returns %#x\n", GetLastError());
+        fprintf(stderr, "MCToMB error; GetLastError returns %#x\n", GetLastError());
         free(lpWideCharStr);
         return NULL;
     }
@@ -296,7 +296,7 @@ uint32_t UTIL_MachErrorToPalError(kern_return_t MachReturn)
         return ERROR_INVALID_PARAMETER;
 
     default:
-        ASSERT("Unknown kern_return_t value %d - reporting ERROR_INTERNAL_ERROR\n", MachReturn);
+        fprintf(stderr, "Unknown kern_return_t value %d - reporting ERROR_INTERNAL_ERROR\n", MachReturn);
         return ERROR_INTERNAL_ERROR;
     }
 }

--- a/chakracore-cxx/pal/src/objmgr/shmobject.cpp
+++ b/chakracore-cxx/pal/src/objmgr/shmobject.cpp
@@ -22,6 +22,7 @@ Abstract:
 #include <new>
 #include "pal/cs.hpp"
 #include "pal/dbgmsg.h"
+#include "chakra/Logger.h"
 
 #include <stddef.h>
 
@@ -84,7 +85,7 @@ CSharedMemoryObject::Initialize(
             //
             if (NULL == psmod)
             {
-                fprintf(stderr, "psmod should not be NULL");
+                chakra::Logger::error("psmod should not be NULL");
                 palError = ERROR_INTERNAL_ERROR;
                 goto InitializeExit;
             } 
@@ -92,7 +93,7 @@ CSharedMemoryObject::Initialize(
             m_pvSharedData = SHMPTR_TO_TYPED_PTR(void, psmod->shmObjSharedData);
             if (NULL == m_pvSharedData)
             {
-                fprintf(stderr, "Unable to map shared data area\n");
+                chakra::Logger::error("Unable to map shared data area\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto InitializeExit;
             }
@@ -172,7 +173,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
     psmod = SHMPTR_TO_TYPED_PTR(SHMObjData, m_shmod);
     if (NULL == psmod)
     {
-        fprintf(stderr, "Unable to map shared object data\n");
+        chakra::Logger::error("Unable to map shared object data\n");
         palError = ERROR_INTERNAL_ERROR;
         goto InitializeFromExistingSharedDataExit;
     }
@@ -197,7 +198,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         }
         else
         {
-            fprintf(stderr, "Unable to map object name\n");
+            chakra::Logger::error("Unable to map object name\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -232,7 +233,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         }
         else
         {
-            fprintf(stderr, "Unable to map object immutable data\n");
+            chakra::Logger::error("Unable to map object immutable data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -243,7 +244,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         m_pvSharedData = SHMPTR_TO_TYPED_PTR(void, psmod->shmObjSharedData);
         if (NULL == m_pvSharedData)
         {
-            fprintf(stderr, "Unable to map object shared data\n");
+            chakra::Logger::error("Unable to map object shared data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -744,7 +745,7 @@ CSharedMemoryObject::DereferenceSharedData()
 
                         if (!SHMSetInfo(SIID_NAMED_OBJECTS, psmod->shmNextObj))
                         {
-                            fprintf(stderr, "Failed to set shared named object list head");
+                            chakra::Logger::error("Failed to set shared named object list head");
                         }
                     }
 
@@ -779,7 +780,7 @@ CSharedMemoryObject::DereferenceSharedData()
     }
     else
     {
-        fprintf(stderr, "Multiple calls to DereferenceSharedData\n");
+        chakra::Logger::error("Multiple calls to DereferenceSharedData\n");
     }
 
     LOGEXIT("CSharedMemoryObject::DereferenceSharedData returns %d\n",
@@ -800,7 +801,7 @@ CSharedMemoryObject::~CSharedMemoryObject()
 {
     if (!m_fSharedDataDereferenced)
     {
-        fprintf(stderr, "DereferenceSharedData not called before object destructor -- delete called directly?\n");
+        chakra::Logger::error("DereferenceSharedData not called before object destructor -- delete called directly?\n");
         DereferenceSharedData();
     }
 
@@ -959,7 +960,7 @@ CSharedMemoryObject::GetSynchStateController(
     // This is not a waitable object!
     //
 
-    fprintf(stderr, "Attempt to obtain a synch state controller on a non-waitable object\n");
+    chakra::Logger::error("Attempt to obtain a synch state controller on a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -989,7 +990,7 @@ CSharedMemoryObject::GetSynchWaitController(
     // This is not a waitable object!!!
     //
 
-    fprintf(stderr, "Attempt to obtain a synch wait controller on a non-waitable object\n");
+    chakra::Logger::error("Attempt to obtain a synch wait controller on a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -1034,7 +1035,7 @@ CSharedMemoryObject::GetObjectSynchData(
     // This is not a waitable object!!!
     //
 
-    fprintf(stderr, "Attempt to obtain a synch data for a non-waitable object\n");
+    chakra::Logger::error("Attempt to obtain a synch data for a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -1219,7 +1220,7 @@ CSharedMemoryWaitableObject::~CSharedMemoryWaitableObject()
 {
     if (!m_fSharedDataDereferenced)
     {
-        fprintf(stderr, "DereferenceSharedData not called before object destructor -- delete called directly?\n");
+        chakra::Logger::error("DereferenceSharedData not called before object destructor -- delete called directly?\n");
         DereferenceSharedData();
     }
     

--- a/chakracore-cxx/pal/src/objmgr/shmobject.cpp
+++ b/chakracore-cxx/pal/src/objmgr/shmobject.cpp
@@ -84,7 +84,7 @@ CSharedMemoryObject::Initialize(
             //
             if (NULL == psmod)
             {
-                ASSERT("psmod should not be NULL");
+                fprintf(stderr, "psmod should not be NULL");
                 palError = ERROR_INTERNAL_ERROR;
                 goto InitializeExit;
             } 
@@ -92,7 +92,7 @@ CSharedMemoryObject::Initialize(
             m_pvSharedData = SHMPTR_TO_TYPED_PTR(void, psmod->shmObjSharedData);
             if (NULL == m_pvSharedData)
             {
-                ASSERT("Unable to map shared data area\n");
+                fprintf(stderr, "Unable to map shared data area\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto InitializeExit;
             }
@@ -172,7 +172,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
     psmod = SHMPTR_TO_TYPED_PTR(SHMObjData, m_shmod);
     if (NULL == psmod)
     {
-        ASSERT("Unable to map shared object data\n");
+        fprintf(stderr, "Unable to map shared object data\n");
         palError = ERROR_INTERNAL_ERROR;
         goto InitializeFromExistingSharedDataExit;
     }
@@ -197,7 +197,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         }
         else
         {
-            ASSERT("Unable to map object name\n");
+            fprintf(stderr, "Unable to map object name\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -232,7 +232,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         }
         else
         {
-            ASSERT("Unable to map object immutable data\n");
+            fprintf(stderr, "Unable to map object immutable data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -243,7 +243,7 @@ CSharedMemoryObject::InitializeFromExistingSharedData(
         m_pvSharedData = SHMPTR_TO_TYPED_PTR(void, psmod->shmObjSharedData);
         if (NULL == m_pvSharedData)
         {
-            ASSERT("Unable to map object shared data\n");
+            fprintf(stderr, "Unable to map object shared data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto InitializeFromExistingSharedDataExit;
         }
@@ -744,7 +744,7 @@ CSharedMemoryObject::DereferenceSharedData()
 
                         if (!SHMSetInfo(SIID_NAMED_OBJECTS, psmod->shmNextObj))
                         {
-                            ASSERT("Failed to set shared named object list head");
+                            fprintf(stderr, "Failed to set shared named object list head");
                         }
                     }
 
@@ -779,7 +779,7 @@ CSharedMemoryObject::DereferenceSharedData()
     }
     else
     {
-        ASSERT("Multiple calls to DereferenceSharedData\n");
+        fprintf(stderr, "Multiple calls to DereferenceSharedData\n");
     }
 
     LOGEXIT("CSharedMemoryObject::DereferenceSharedData returns %d\n",
@@ -800,7 +800,7 @@ CSharedMemoryObject::~CSharedMemoryObject()
 {
     if (!m_fSharedDataDereferenced)
     {
-        ASSERT("DereferenceSharedData not called before object destructor -- delete called directly?\n");
+        fprintf(stderr, "DereferenceSharedData not called before object destructor -- delete called directly?\n");
         DereferenceSharedData();
     }
 
@@ -959,7 +959,7 @@ CSharedMemoryObject::GetSynchStateController(
     // This is not a waitable object!
     //
 
-    ASSERT("Attempt to obtain a synch state controller on a non-waitable object\n");
+    fprintf(stderr, "Attempt to obtain a synch state controller on a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -989,7 +989,7 @@ CSharedMemoryObject::GetSynchWaitController(
     // This is not a waitable object!!!
     //
 
-    ASSERT("Attempt to obtain a synch wait controller on a non-waitable object\n");
+    fprintf(stderr, "Attempt to obtain a synch wait controller on a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -1034,7 +1034,7 @@ CSharedMemoryObject::GetObjectSynchData(
     // This is not a waitable object!!!
     //
 
-    ASSERT("Attempt to obtain a synch data for a non-waitable object\n");
+    fprintf(stderr, "Attempt to obtain a synch data for a non-waitable object\n");
     return ERROR_INVALID_HANDLE;
 }
 
@@ -1219,7 +1219,7 @@ CSharedMemoryWaitableObject::~CSharedMemoryWaitableObject()
 {
     if (!m_fSharedDataDereferenced)
     {
-        ASSERT("DereferenceSharedData not called before object destructor -- delete called directly?\n");
+        fprintf(stderr, "DereferenceSharedData not called before object destructor -- delete called directly?\n");
         DereferenceSharedData();
     }
     

--- a/chakracore-cxx/pal/src/objmgr/shmobjectmanager.cpp
+++ b/chakracore-cxx/pal/src/objmgr/shmobjectmanager.cpp
@@ -318,7 +318,7 @@ CSharedMemoryObjectManager::RegisterObject(
         psmodNew = SHMPTR_TO_TYPED_PTR(SHMObjData, pshmobj->GetShmObjData());
         if (NULL == psmodNew)
         {
-            ASSERT("Failure to map shared object data\n");
+            fprintf(stderr, "Failure to map shared object data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -336,7 +336,7 @@ CSharedMemoryObjectManager::RegisterObject(
             }
             else
             {
-                ASSERT("Failure to map shared object data\n");
+                fprintf(stderr, "Failure to map shared object data\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto RegisterObjectExit;
             }
@@ -346,7 +346,7 @@ CSharedMemoryObjectManager::RegisterObject(
 
         if (!SHMSetInfo(SIID_NAMED_OBJECTS, pshmobj->GetShmObjData()))
         {
-            ASSERT("Failed to set shared named object list head\n");
+            fprintf(stderr, "Failed to set shared named object list head\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -373,7 +373,7 @@ CSharedMemoryObjectManager::RegisterObject(
         palError = pobjToRegister->GetImmutableData(&pvImmutableData);
         if (NO_ERROR != palError)
         {
-            ASSERT("Failure to obtain object immutable data\n");
+            fprintf(stderr, "Failure to obtain object immutable data\n");
             goto RegisterObjectExit;
         }
 
@@ -393,14 +393,14 @@ CSharedMemoryObjectManager::RegisterObject(
             }
             else
             {
-                ASSERT("Failure to map psmod->shmObjImmutableData\n");
+                fprintf(stderr, "Failure to map psmod->shmObjImmutableData\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto RegisterObjectExit;
             }
         }
         else
         {
-            ASSERT("Failure to map pshmobj->GetShmObjData()\n");
+            fprintf(stderr, "Failure to map pshmobj->GetShmObjData()\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -581,7 +581,7 @@ CSharedMemoryObjectManager::LocateObject(
                 }
                 else
                 {
-                    ASSERT("Unable to map psmod->shmObjName\n");
+                    fprintf(stderr, "Unable to map psmod->shmObjName\n");
                     break;
                 }                
             }
@@ -590,7 +590,7 @@ CSharedMemoryObjectManager::LocateObject(
         }
         else
         {
-            ASSERT("Unable to map shmObjectListEntry\n");
+            fprintf(stderr, "Unable to map shmObjectListEntry\n");
             break;
         }
     }
@@ -618,7 +618,7 @@ CSharedMemoryObjectManager::LocateObject(
         CObjectType *pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
-            ASSERT("Invalid object type ID in shared memory info\n");
+            fprintf(stderr, "Invalid object type ID in shared memory info\n");
             goto LocateObjectExitSHMRelease;
         }
 
@@ -710,7 +710,7 @@ CSharedMemoryObjectManager::ObtainHandleForObject(
         // Not yet supported
         //
 
-        ASSERT("Caller to ObtainHandleForObject provided a process\n");
+        fprintf(stderr, "Caller to ObtainHandleForObject provided a process\n");
         return ERROR_CALL_NOT_IMPLEMENTED;
     }
 
@@ -1162,7 +1162,7 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
         pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
-            ASSERT("Invalid object type ID in shared memory info\n");
+            fprintf(stderr, "Invalid object type ID in shared memory info\n");
             goto ConvertRemoteHandleToLocalExit;
         }
         

--- a/chakracore-cxx/pal/src/objmgr/shmobjectmanager.cpp
+++ b/chakracore-cxx/pal/src/objmgr/shmobjectmanager.cpp
@@ -25,6 +25,7 @@ Abstract:
 #include "pal/thread.hpp"
 #include "pal/procobj.hpp"
 #include "pal/dbgmsg.h"
+#include "chakra/Logger.h"
 
 SET_DEFAULT_DEBUG_CHANNEL(PAL);
 
@@ -318,7 +319,7 @@ CSharedMemoryObjectManager::RegisterObject(
         psmodNew = SHMPTR_TO_TYPED_PTR(SHMObjData, pshmobj->GetShmObjData());
         if (NULL == psmodNew)
         {
-            fprintf(stderr, "Failure to map shared object data\n");
+            chakra::Logger::error("Failure to map shared object data\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -336,7 +337,7 @@ CSharedMemoryObjectManager::RegisterObject(
             }
             else
             {
-                fprintf(stderr, "Failure to map shared object data\n");
+                chakra::Logger::error("Failure to map shared object data\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto RegisterObjectExit;
             }
@@ -346,7 +347,7 @@ CSharedMemoryObjectManager::RegisterObject(
 
         if (!SHMSetInfo(SIID_NAMED_OBJECTS, pshmobj->GetShmObjData()))
         {
-            fprintf(stderr, "Failed to set shared named object list head\n");
+            chakra::Logger::error("Failed to set shared named object list head\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -373,7 +374,7 @@ CSharedMemoryObjectManager::RegisterObject(
         palError = pobjToRegister->GetImmutableData(&pvImmutableData);
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Failure to obtain object immutable data\n");
+            chakra::Logger::error("Failure to obtain object immutable data\n");
             goto RegisterObjectExit;
         }
 
@@ -393,14 +394,14 @@ CSharedMemoryObjectManager::RegisterObject(
             }
             else
             {
-                fprintf(stderr, "Failure to map psmod->shmObjImmutableData\n");
+                chakra::Logger::error("Failure to map psmod->shmObjImmutableData\n");
                 palError = ERROR_INTERNAL_ERROR;
                 goto RegisterObjectExit;
             }
         }
         else
         {
-            fprintf(stderr, "Failure to map pshmobj->GetShmObjData()\n");
+            chakra::Logger::error("Failure to map pshmobj->GetShmObjData()\n");
             palError = ERROR_INTERNAL_ERROR;
             goto RegisterObjectExit;
         }
@@ -581,7 +582,7 @@ CSharedMemoryObjectManager::LocateObject(
                 }
                 else
                 {
-                    fprintf(stderr, "Unable to map psmod->shmObjName\n");
+                    chakra::Logger::error("Unable to map psmod->shmObjName\n");
                     break;
                 }                
             }
@@ -590,7 +591,7 @@ CSharedMemoryObjectManager::LocateObject(
         }
         else
         {
-            fprintf(stderr, "Unable to map shmObjectListEntry\n");
+            chakra::Logger::error("Unable to map shmObjectListEntry\n");
             break;
         }
     }
@@ -618,7 +619,7 @@ CSharedMemoryObjectManager::LocateObject(
         CObjectType *pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
-            fprintf(stderr, "Invalid object type ID in shared memory info\n");
+            chakra::Logger::error("Invalid object type ID in shared memory info\n");
             goto LocateObjectExitSHMRelease;
         }
 
@@ -710,7 +711,7 @@ CSharedMemoryObjectManager::ObtainHandleForObject(
         // Not yet supported
         //
 
-        fprintf(stderr, "Caller to ObtainHandleForObject provided a process\n");
+        chakra::Logger::error("Caller to ObtainHandleForObject provided a process\n");
         return ERROR_CALL_NOT_IMPLEMENTED;
     }
 
@@ -1162,7 +1163,7 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
         pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
-            fprintf(stderr, "Invalid object type ID in shared memory info\n");
+            chakra::Logger::error("Invalid object type ID in shared memory info\n");
             goto ConvertRemoteHandleToLocalExit;
         }
         

--- a/chakracore-cxx/pal/src/shmemory/shmemory.cpp
+++ b/chakracore-cxx/pal/src/shmemory/shmemory.cpp
@@ -157,6 +157,7 @@ is still alive).
 
 #include <mutex>
 #include <string>
+#include <format>
 
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
@@ -468,8 +469,8 @@ void SHMCleanup(void)
         if ( -1 == munmap( shm_segment_bases[ shm_numsegments ],
                            segment_size ) )
         {
-            fprintf(stderr, "munmap() failed; errno is %d (%s).\n",
-                  errno, strerror( errno ) );
+            chakra::Logger::error(std::format("munmap() failed; errno is {} ({}).\n",
+                  errno, strerror( errno ) ));
         }
     }
 
@@ -523,8 +524,8 @@ SHMPTR SHMalloc(size_t size)
     /* If no block size is found, requested size was too large. */
     if( SPS_LAST == sps )
     {
-        fprintf(stderr, "Got request for shared memory block of %u bytes; maximum block "
-              "size is %d.\n", size, block_sizes[SPS_LAST-1]);
+        chakra::Logger::error(std::format("Got request for shared memory block of {} bytes; maximum block "
+              "size is %d.\n", size, block_sizes[SPS_LAST-1]));
         return 0;
     }
 
@@ -556,8 +557,8 @@ SHMPTR SHMalloc(size_t size)
 
     if( 0 == first_free )
     {
-        fprintf(stderr, "First free block in %d-byte pool (%08x) was invalid!\n",
-              block_sizes[sps], first_free);
+        chakra::Logger::error(std::format("First free block in {}-byte pool ({:08x}) was invalid!\n",
+              block_sizes[sps], first_free));
         SHMRelease();
         return 0;
     }
@@ -572,16 +573,16 @@ SHMPTR SHMalloc(size_t size)
     if(( 0 == header->pools[sps].free_items && 0 != next_free) ||
        ( 0 != header->pools[sps].free_items && 0 == next_free))
     {
-        fprintf(stderr, "free block count is %d, but next free block is %#x\n",
-               header->pools[sps].free_items, next_free);
+        chakra::Logger::error(std::format("free block count is {}, but next free block is {:#x}\n",
+               header->pools[sps].free_items, next_free));
         /* assume all remaining blocks in the pool are corrupt */
         header->pools[sps].first_free = 0;
         header->pools[sps].free_items = 0;
     }
     else if (0 != next_free && 0 == SHMPTR_TO_PTR(next_free) )
     {
-        fprintf(stderr, "Next free block (%#x) in %d-byte pool is invalid!\n",
-               next_free, block_sizes[sps]);
+        chakra::Logger::error(std::format("Next free block ({:#x}) in {}-byte pool is invalid!\n",
+               next_free, block_sizes[sps]));
         /* assume all remaining blocks in the pool are corrupt */
         header->pools[sps].first_free = 0;
         header->pools[sps].free_items = 0;
@@ -626,7 +627,7 @@ void SHMfree(SHMPTR shmptr)
 
     if(!shmptr_ptr)
     {
-        fprintf(stderr, "Tried to free an invalid shared memory pointer 0x%08x\n", shmptr);
+        chakra::Logger::error(std::format("Tried to free an invalid shared memory pointer 0x{:08x}\n", shmptr));
         SHMRelease();
         return;
     }
@@ -653,7 +654,7 @@ void SHMfree(SHMPTR shmptr)
        have caught this.)  */
     if(sps == SPS_LAST)
     {
-        fprintf(stderr, "Shared memory pointer 0x%08x is out of bounds!\n", shmptr);
+        chakra::Logger::error(std::format("Shared memory pointer 0x{:08x} is out of bounds!\n", shmptr));
         SHMRelease();
         return;
     }
@@ -669,7 +670,7 @@ void SHMfree(SHMPTR shmptr)
        this isn't a real SHMPTR */
     if( 0 != ( offset % block_sizes[sps] ) )
     {
-        fprintf(stderr, "Shared memory pointer 0x%08x is misaligned!\n", shmptr);
+        chakra::Logger::error(std::format("Shared memory pointer 0x{:08x} is misaligned!\n", shmptr));
         SHMRelease();
         return;
     }
@@ -782,7 +783,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
         /* if segment is still unknown, then it doesn't exist */
         if(segment>=shm_numsegments)
         {
-            fprintf(stderr, "Segment %d still unknown; returning NULL\n", segment);
+            chakra::Logger::error(std::format("Segment {} still unknown; returning NULL\n", segment));
             return NULL;
         }
         TRACE("Segment %d found; continuing\n", segment);
@@ -792,8 +793,8 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     offset = SHMPTR_OFFSET(shmptr);
     if(offset>=segment_size)
     {
-        fprintf(stderr, "Offset %d is larger than segment size (%d)! returning NULL\n",
-              offset, segment_size);
+        chakra::Logger::error(std::format("Offset {} is larger than segment size ({})! returning NULL\n",
+              offset, segment_size));
         return NULL;
 
     }
@@ -803,7 +804,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     {
         if (static_cast<size_t>(offset) < roundup(sizeof(SHM_FIRST_HEADER), sizeof(int64_t)))
         {
-            fprintf(stderr, "Offset %d is in segment header! returning NULL\n", offset);
+            chakra::Logger::error(std::format("Offset {} is in segment header! returning NULL\n", offset));
             return NULL;
         }
     }
@@ -811,7 +812,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     {
         if (static_cast<size_t>(offset) < sizeof(SHM_SEGMENT_HEADER))
         {
-            fprintf(stderr, "Offset %d is in segment header! returning NULL\n", offset);
+            chakra::Logger::error(std::format("Offset {} is in segment header! returning NULL\n", offset));
             return NULL;
         }
     }
@@ -847,7 +848,7 @@ SHMPTR SHMGetInfo(SHM_INFO_ID element)
 
     if(element >= SIID_LAST)
     {
-        fprintf(stderr, "Invalid SHM info element %d\n", element);
+        chakra::Logger::error(std::format("Invalid SHM info element {}\n", static_cast<int>(element)));
         return 0;
     }
 
@@ -889,7 +890,7 @@ BOOL SHMSetInfo(SHM_INFO_ID element, SHMPTR value)
 
     if(element >= SIID_LAST)
     {
-        fprintf(stderr, "Invalid SHM info element %d\n", element);
+        chakra::Logger::error(std::format("Invalid SHM info element {}\n", static_cast<int>(element)));
         return FALSE;
     }
 

--- a/chakracore-cxx/pal/src/shmemory/shmemory.cpp
+++ b/chakracore-cxx/pal/src/shmemory/shmemory.cpp
@@ -467,7 +467,7 @@ void SHMCleanup(void)
         if ( -1 == munmap( shm_segment_bases[ shm_numsegments ],
                            segment_size ) )
         {
-            ASSERT( "munmap() failed; errno is %d (%s).\n",
+            fprintf(stderr, "munmap() failed; errno is %d (%s).\n",
                   errno, strerror( errno ) );
         }
     }
@@ -522,7 +522,7 @@ SHMPTR SHMalloc(size_t size)
     /* If no block size is found, requested size was too large. */
     if( SPS_LAST == sps )
     {
-        ASSERT("Got request for shared memory block of %u bytes; maximum block "
+        fprintf(stderr, "Got request for shared memory block of %u bytes; maximum block "
               "size is %d.\n", size, block_sizes[SPS_LAST-1]);
         return 0;
     }
@@ -555,7 +555,7 @@ SHMPTR SHMalloc(size_t size)
 
     if( 0 == first_free )
     {
-        ASSERT("First free block in %d-byte pool (%08x) was invalid!\n",
+        fprintf(stderr, "First free block in %d-byte pool (%08x) was invalid!\n",
               block_sizes[sps], first_free);
         SHMRelease();
         return 0;
@@ -571,7 +571,7 @@ SHMPTR SHMalloc(size_t size)
     if(( 0 == header->pools[sps].free_items && 0 != next_free) ||
        ( 0 != header->pools[sps].free_items && 0 == next_free))
     {
-        ASSERT("free block count is %d, but next free block is %#x\n",
+        fprintf(stderr, "free block count is %d, but next free block is %#x\n",
                header->pools[sps].free_items, next_free);
         /* assume all remaining blocks in the pool are corrupt */
         header->pools[sps].first_free = 0;
@@ -579,7 +579,7 @@ SHMPTR SHMalloc(size_t size)
     }
     else if (0 != next_free && 0 == SHMPTR_TO_PTR(next_free) )
     {
-        ASSERT("Next free block (%#x) in %d-byte pool is invalid!\n",
+        fprintf(stderr, "Next free block (%#x) in %d-byte pool is invalid!\n",
                next_free, block_sizes[sps]);
         /* assume all remaining blocks in the pool are corrupt */
         header->pools[sps].first_free = 0;
@@ -625,7 +625,7 @@ void SHMfree(SHMPTR shmptr)
 
     if(!shmptr_ptr)
     {
-        ASSERT("Tried to free an invalid shared memory pointer 0x%08x\n", shmptr);
+        fprintf(stderr, "Tried to free an invalid shared memory pointer 0x%08x\n", shmptr);
         SHMRelease();
         return;
     }
@@ -652,7 +652,7 @@ void SHMfree(SHMPTR shmptr)
        have caught this.)  */
     if(sps == SPS_LAST)
     {
-        ASSERT("Shared memory pointer 0x%08x is out of bounds!\n", shmptr);
+        fprintf(stderr, "Shared memory pointer 0x%08x is out of bounds!\n", shmptr);
         SHMRelease();
         return;
     }
@@ -668,7 +668,7 @@ void SHMfree(SHMPTR shmptr)
        this isn't a real SHMPTR */
     if( 0 != ( offset % block_sizes[sps] ) )
     {
-        ASSERT("Shared memory pointer 0x%08x is misaligned!\n", shmptr);
+        fprintf(stderr, "Shared memory pointer 0x%08x is misaligned!\n", shmptr);
         SHMRelease();
         return;
     }
@@ -781,7 +781,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
         /* if segment is still unknown, then it doesn't exist */
         if(segment>=shm_numsegments)
         {
-            ASSERT("Segment %d still unknown; returning NULL\n", segment);
+            fprintf(stderr, "Segment %d still unknown; returning NULL\n", segment);
             return NULL;
         }
         TRACE("Segment %d found; continuing\n", segment);
@@ -791,7 +791,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     offset = SHMPTR_OFFSET(shmptr);
     if(offset>=segment_size)
     {
-        ASSERT("Offset %d is larger than segment size (%d)! returning NULL\n",
+        fprintf(stderr, "Offset %d is larger than segment size (%d)! returning NULL\n",
               offset, segment_size);
         return NULL;
 
@@ -802,7 +802,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     {
         if (static_cast<size_t>(offset) < roundup(sizeof(SHM_FIRST_HEADER), sizeof(int64_t)))
         {
-            ASSERT("Offset %d is in segment header! returning NULL\n", offset);
+            fprintf(stderr, "Offset %d is in segment header! returning NULL\n", offset);
             return NULL;
         }
     }
@@ -810,7 +810,7 @@ void * SHMPtrToPtr(SHMPTR shmptr)
     {
         if (static_cast<size_t>(offset) < sizeof(SHM_SEGMENT_HEADER))
         {
-            ASSERT("Offset %d is in segment header! returning NULL\n", offset);
+            fprintf(stderr, "Offset %d is in segment header! returning NULL\n", offset);
             return NULL;
         }
     }
@@ -846,7 +846,7 @@ SHMPTR SHMGetInfo(SHM_INFO_ID element)
 
     if(element >= SIID_LAST)
     {
-        ASSERT("Invalid SHM info element %d\n", element);
+        fprintf(stderr, "Invalid SHM info element %d\n", element);
         return 0;
     }
 
@@ -854,7 +854,7 @@ SHMPTR SHMGetInfo(SHM_INFO_ID element)
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( reinterpret_cast<HANDLE>(pthread_self()) != locking_thread )
     {
-        ASSERT("SHMGetInfo called while thread does not hold the SHM lock!\n");
+        fprintf(stderr, "SHMGetInfo called while thread does not hold the SHM lock!\n");
     }
 
     header = static_cast<SHM_FIRST_HEADER*>(shm_segment_bases[0].Load());
@@ -888,7 +888,7 @@ BOOL SHMSetInfo(SHM_INFO_ID element, SHMPTR value)
 
     if(element >= SIID_LAST)
     {
-        ASSERT("Invalid SHM info element %d\n", element);
+        fprintf(stderr, "Invalid SHM info element %d\n", element);
         return FALSE;
     }
 
@@ -896,7 +896,7 @@ BOOL SHMSetInfo(SHM_INFO_ID element, SHMPTR value)
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( reinterpret_cast<HANDLE>(pthread_self()) != locking_thread )
     {
-        ASSERT("SHMGetInfo called while thread does not hold the SHM lock!\n");
+        fprintf(stderr, "SHMGetInfo called while thread does not hold the SHM lock!\n");
     }
 
     header = static_cast<SHM_FIRST_HEADER*>(shm_segment_bases[0].Load());
@@ -1307,13 +1307,13 @@ SHMPTR SHMFindNamedObjectByName( const char16_t* lpName, SHM_NAMED_OBJECTS_ID oi
 
     if(oid==SHM_NAMED_LAST)
     {
-        ASSERT("Invalid named object type.\n");
+        fprintf(stderr, "Invalid named object type.\n");
         return 0;
     }
 
     if (pbNameExists == NULL)
     {
-        ASSERT("pbNameExists must be non-NULL.\n");
+        fprintf(stderr, "pbNameExists must be non-NULL.\n");
     }
 
     SHMLock();
@@ -1329,7 +1329,7 @@ SHMPTR SHMFindNamedObjectByName( const char16_t* lpName, SHM_NAMED_OBJECTS_ID oi
         pNamedObject = static_cast<PSHM_NAMED_OBJECTS>(SHMPTR_TO_PTR(shmNamedObject));
         if(NULL == pNamedObject)
         {
-            ASSERT("Got invalid SHMPTR value; list of named objects is "
+            fprintf(stderr, "Got invalid SHMPTR value; list of named objects is "
                    "corrupted.\n");
             break;
         }
@@ -1435,7 +1435,7 @@ void SHMAddNamedObject( SHMPTR shmNewNamedObject )
 
     if ( pshmNew == NULL )
     {
-        ASSERT( "pshmNew should not be NULL\n" );
+        fprintf(stderr, "pshmNew should not be NULL\n" );
     }
 
     SHMLock();
@@ -1444,7 +1444,7 @@ void SHMAddNamedObject( SHMPTR shmNewNamedObject )
 
     if ( !SHMSetInfo( SIID_NAMED_OBJECTS, shmNewNamedObject ) )
     {
-        ASSERT( "Unable to add the mapping object to shared memory.\n" );
+        fprintf(stderr, "Unable to add the mapping object to shared memory.\n" );
     }
 
     SHMRelease();

--- a/chakracore-cxx/pal/src/shmemory/shmemory.cpp
+++ b/chakracore-cxx/pal/src/shmemory/shmemory.cpp
@@ -176,6 +176,7 @@ is still alive).
 #include <string.h>
 #include <sched.h>
 #include <pthread.h>
+#include "chakra/Logger.h"
 
 SET_DEFAULT_DEBUG_CHANNEL(SHMEM);
 
@@ -854,7 +855,7 @@ SHMPTR SHMGetInfo(SHM_INFO_ID element)
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( reinterpret_cast<HANDLE>(pthread_self()) != locking_thread )
     {
-        fprintf(stderr, "SHMGetInfo called while thread does not hold the SHM lock!\n");
+        chakra::Logger::error("SHMGetInfo called while thread does not hold the SHM lock!\n");
     }
 
     header = static_cast<SHM_FIRST_HEADER*>(shm_segment_bases[0].Load());
@@ -896,7 +897,7 @@ BOOL SHMSetInfo(SHM_INFO_ID element, SHMPTR value)
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( reinterpret_cast<HANDLE>(pthread_self()) != locking_thread )
     {
-        fprintf(stderr, "SHMGetInfo called while thread does not hold the SHM lock!\n");
+        chakra::Logger::error("SHMGetInfo called while thread does not hold the SHM lock!\n");
     }
 
     header = static_cast<SHM_FIRST_HEADER*>(shm_segment_bases[0].Load());
@@ -1307,13 +1308,13 @@ SHMPTR SHMFindNamedObjectByName( const char16_t* lpName, SHM_NAMED_OBJECTS_ID oi
 
     if(oid==SHM_NAMED_LAST)
     {
-        fprintf(stderr, "Invalid named object type.\n");
+        chakra::Logger::error("Invalid named object type.\n");
         return 0;
     }
 
     if (pbNameExists == NULL)
     {
-        fprintf(stderr, "pbNameExists must be non-NULL.\n");
+        chakra::Logger::error("pbNameExists must be non-NULL.\n");
     }
 
     SHMLock();
@@ -1329,7 +1330,7 @@ SHMPTR SHMFindNamedObjectByName( const char16_t* lpName, SHM_NAMED_OBJECTS_ID oi
         pNamedObject = static_cast<PSHM_NAMED_OBJECTS>(SHMPTR_TO_PTR(shmNamedObject));
         if(NULL == pNamedObject)
         {
-            fprintf(stderr, "Got invalid SHMPTR value; list of named objects is "
+            chakra::Logger::error("Got invalid SHMPTR value; list of named objects is "
                    "corrupted.\n");
             break;
         }
@@ -1435,7 +1436,7 @@ void SHMAddNamedObject( SHMPTR shmNewNamedObject )
 
     if ( pshmNew == NULL )
     {
-        fprintf(stderr, "pshmNew should not be NULL\n" );
+        chakra::Logger::error("pshmNew should not be NULL\n" );
     }
 
     SHMLock();
@@ -1444,7 +1445,7 @@ void SHMAddNamedObject( SHMPTR shmNewNamedObject )
 
     if ( !SHMSetInfo( SIID_NAMED_OBJECTS, shmNewNamedObject ) )
     {
-        fprintf(stderr, "Unable to add the mapping object to shared memory.\n" );
+        chakra::Logger::error("Unable to add the mapping object to shared memory.\n" );
     }
 
     SHMRelease();

--- a/chakracore-cxx/pal/src/sync/cs.cpp
+++ b/chakracore-cxx/pal/src/sync/cs.cpp
@@ -23,6 +23,8 @@
 
 #include <sched.h>
 #include <pthread.h>
+#include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -312,8 +314,8 @@ void InternalDeleteCriticalSection(
             if (tid != pPalCriticalSection->OwningThread)
             {
                 // not owner
-                fprintf(stderr, "Thread tid=%u deleting a CS owned by thread tid=%u\n",
-                       tid, pPalCriticalSection->OwningThread);
+                chakra::Logger::error(std::format("Thread tid={} deleting a CS owned by thread tid={}\n",
+                       tid, pPalCriticalSection->OwningThread));
             }
             else
             {
@@ -1029,8 +1031,8 @@ namespace CorUnix
             iRet = pthread_mutex_init(&pPalCriticalSection->csndNativeData.mutex, NULL);
             if (0 != iRet)
             {
-                fprintf(stderr, "Failed initializing mutex in CS @ %p [err=%d]\n",
-                        pPalCriticalSection, iRet);
+                chakra::Logger::error(std::format("Failed initializing mutex in CS @ {} [err={}]\n",
+                        static_cast<void *>(pPalCriticalSection), iRet));
                 pPalCriticalSection->cisInitState = PalCsUserInitialized;
                 fRet = false;
                 goto PCDI_exit;
@@ -1040,8 +1042,8 @@ namespace CorUnix
             iRet = pthread_cond_init(&pPalCriticalSection->csndNativeData.condition, NULL);
             if (0 != iRet)
             {
-                fprintf(stderr, "Failed initializing condition in CS @ %p [err=%d]\n",
-                       pPalCriticalSection, iRet);
+                chakra::Logger::error(std::format("Failed initializing condition in CS @ {} [err={}]\n",
+                       static_cast<void *>(pPalCriticalSection), iRet));
                 pthread_mutex_destroy(&pPalCriticalSection->csndNativeData.mutex);
                 pPalCriticalSection->cisInitState = PalCsUserInitialized;
                 fRet = false;
@@ -1063,7 +1065,7 @@ namespace CorUnix
         }
         else
         {
-            fprintf(stderr, "CS %p is not initialized", pPalCriticalSection);
+            chakra::Logger::error(std::format("CS {} is not initialized", static_cast<void *>(pPalCriticalSection)));
             fRet = false;
             goto PCDI_exit;
         }
@@ -1192,8 +1194,8 @@ namespace CorUnix
             if (0 != iRet)
             {
                 // Failed: unlock the mutex and bail out
-                fprintf(stderr, "Failed waiting on condition in CS %p [err=%d]\n",
-                       pPalCriticalSection, iRet);
+                chakra::Logger::error(std::format("Failed waiting on condition in CS {} [err={}]\n",
+                       static_cast<void *>(pPalCriticalSection), iRet));
                 pthread_mutex_unlock(&pPalCriticalSection->csndNativeData.mutex);
                 palErr = ERROR_INTERNAL_ERROR;
                 goto PCDAW_exit;
@@ -1252,8 +1254,8 @@ namespace CorUnix
         {
             // Failed: set palErr, but continue in order to unlock
             // the mutex anyway
-            fprintf(stderr, "Failed setting condition in CS %p [ret=%d]\n",
-                   pPalCriticalSection, iRet);
+            chakra::Logger::error(std::format("Failed setting condition in CS {} [ret={}]\n",
+                   static_cast<void *>(pPalCriticalSection), iRet));
             palErr = ERROR_INTERNAL_ERROR;
         }
 

--- a/chakracore-cxx/pal/src/sync/cs.cpp
+++ b/chakracore-cxx/pal/src/sync/cs.cpp
@@ -312,7 +312,7 @@ void InternalDeleteCriticalSection(
             if (tid != pPalCriticalSection->OwningThread)
             {
                 // not owner
-                ASSERT("Thread tid=%u deleting a CS owned by thread tid=%u\n",
+                fprintf(stderr, "Thread tid=%u deleting a CS owned by thread tid=%u\n",
                        tid, pPalCriticalSection->OwningThread);
             }
             else
@@ -1029,7 +1029,7 @@ namespace CorUnix
             iRet = pthread_mutex_init(&pPalCriticalSection->csndNativeData.mutex, NULL);
             if (0 != iRet)
             {
-                ASSERT("Failed initializing mutex in CS @ %p [err=%d]\n",
+                fprintf(stderr, "Failed initializing mutex in CS @ %p [err=%d]\n",
                         pPalCriticalSection, iRet);
                 pPalCriticalSection->cisInitState = PalCsUserInitialized;
                 fRet = false;
@@ -1040,7 +1040,7 @@ namespace CorUnix
             iRet = pthread_cond_init(&pPalCriticalSection->csndNativeData.condition, NULL);
             if (0 != iRet)
             {
-                ASSERT("Failed initializing condition in CS @ %p [err=%d]\n",
+                fprintf(stderr, "Failed initializing condition in CS @ %p [err=%d]\n",
                        pPalCriticalSection, iRet);
                 pthread_mutex_destroy(&pPalCriticalSection->csndNativeData.mutex);
                 pPalCriticalSection->cisInitState = PalCsUserInitialized;
@@ -1063,7 +1063,7 @@ namespace CorUnix
         }
         else
         {
-            ASSERT("CS %p is not initialized", pPalCriticalSection);
+            fprintf(stderr, "CS %p is not initialized", pPalCriticalSection);
             fRet = false;
             goto PCDI_exit;
         }
@@ -1192,7 +1192,7 @@ namespace CorUnix
             if (0 != iRet)
             {
                 // Failed: unlock the mutex and bail out
-                ASSERT("Failed waiting on condition in CS %p [err=%d]\n",
+                fprintf(stderr, "Failed waiting on condition in CS %p [err=%d]\n",
                        pPalCriticalSection, iRet);
                 pthread_mutex_unlock(&pPalCriticalSection->csndNativeData.mutex);
                 palErr = ERROR_INTERNAL_ERROR;
@@ -1252,7 +1252,7 @@ namespace CorUnix
         {
             // Failed: set palErr, but continue in order to unlock
             // the mutex anyway
-            ASSERT("Failed setting condition in CS %p [ret=%d]\n",
+            fprintf(stderr, "Failed setting condition in CS %p [ret=%d]\n",
                    pPalCriticalSection, iRet);
             palErr = ERROR_INTERNAL_ERROR;
         }

--- a/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
@@ -28,6 +28,7 @@ Abstract:
 #include <errno.h>
 #include <limits.h>
 #include "chakra/Logger.h"
+#include <format>
 
 namespace CorUnix
 {
@@ -299,7 +300,7 @@ namespace CorUnix
         {
             if (fSharedObject && (NULLSharedID != shridNewNode))
             {
-                fprintf(stderr, "Bad Shared Memory ptr %p\n", shridNewNode);
+                chakra::Logger::error(std::format("Bad Shared Memory ptr {}\n", shridNewNode));
                 palErr = ERROR_INTERNAL_ERROR;
             }        
             else
@@ -408,7 +409,7 @@ namespace CorUnix
                 }
                 else
                 {
-                    fprintf(stderr, "Unexpected thread wait state %d\n", dwWaitState);
+                    chakra::Logger::error(std::format("Unexpected thread wait state {}\n", dwWaitState));
                     palErr = ERROR_INTERNAL_ERROR;
                 }
                 goto RWT_exit;

--- a/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
@@ -27,6 +27,7 @@ Abstract:
 #include <sched.h>
 #include <errno.h>
 #include <limits.h>
+#include "chakra/Logger.h"
 
 namespace CorUnix
 {
@@ -311,7 +312,7 @@ namespace CorUnix
 
         if (ptwiWaitInfo->lObjCount >= MAXIMUM_WAIT_OBJECTS)
         {
-            fprintf(stderr, "Too many objects");
+            chakra::Logger::error("Too many objects");
             palErr = ERROR_INTERNAL_ERROR; 
             goto RWT_exit;
         }       
@@ -367,7 +368,7 @@ namespace CorUnix
                 // This pointer is set in CSynchWaitController only when the
                 // wait controller for the object is created by calling
                 // GetSynchWaitControllersForObjects
-                fprintf(stderr, "Process synch data pointer is missing\n");
+                chakra::Logger::error("Process synch data pointer is missing\n");
                 palErr = ERROR_INTERNAL_ERROR;
                 goto RWT_exit;
             }
@@ -638,7 +639,7 @@ namespace CorUnix
         
         if (0 != m_psdSynchData->GetOwnershipCount())
         {
-            fprintf(stderr, "Ownership count should be zero at this time\n");
+            chakra::Logger::error("Ownership count should be zero at this time\n");
             palErr = ERROR_INTERNAL_ERROR;
             goto SO_exit;
         }

--- a/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchcontrollers.cpp
@@ -298,7 +298,7 @@ namespace CorUnix
         {
             if (fSharedObject && (NULLSharedID != shridNewNode))
             {
-                ASSERT("Bad Shared Memory ptr %p\n", shridNewNode);
+                fprintf(stderr, "Bad Shared Memory ptr %p\n", shridNewNode);
                 palErr = ERROR_INTERNAL_ERROR;
             }        
             else
@@ -311,7 +311,7 @@ namespace CorUnix
 
         if (ptwiWaitInfo->lObjCount >= MAXIMUM_WAIT_OBJECTS)
         {
-            ASSERT("Too many objects");
+            fprintf(stderr, "Too many objects");
             palErr = ERROR_INTERNAL_ERROR; 
             goto RWT_exit;
         }       
@@ -367,7 +367,7 @@ namespace CorUnix
                 // This pointer is set in CSynchWaitController only when the
                 // wait controller for the object is created by calling
                 // GetSynchWaitControllersForObjects
-                ASSERT("Process synch data pointer is missing\n");
+                fprintf(stderr, "Process synch data pointer is missing\n");
                 palErr = ERROR_INTERNAL_ERROR;
                 goto RWT_exit;
             }
@@ -407,7 +407,7 @@ namespace CorUnix
                 }
                 else
                 {
-                    ASSERT("Unexpected thread wait state %d\n", dwWaitState);
+                    fprintf(stderr, "Unexpected thread wait state %d\n", dwWaitState);
                     palErr = ERROR_INTERNAL_ERROR;
                 }
                 goto RWT_exit;
@@ -638,7 +638,7 @@ namespace CorUnix
         
         if (0 != m_psdSynchData->GetOwnershipCount())
         {
-            ASSERT("Ownership count should be zero at this time\n");
+            fprintf(stderr, "Ownership count should be zero at this time\n");
             palErr = ERROR_INTERNAL_ERROR;
             goto SO_exit;
         }

--- a/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
@@ -32,6 +32,7 @@ Abstract:
 #include <signal.h>
 #include <errno.h>
 #include <poll.h>
+#include <format>
 #include "chakra/Logger.h"
 
 namespace CorUnix
@@ -244,8 +245,8 @@ namespace CorUnix
                     }
                     else
                     {
-                        fprintf(stderr, "Unexpected thread wait state %u\n",
-                               dwWaitState);
+                        chakra::Logger::error(std::format("Unexpected thread wait state {}\n",
+                               dwWaitState));
                         palErr = ERROR_INTERNAL_ERROR;
                     }
                     goto BT_exit;
@@ -1442,9 +1443,9 @@ namespace CorUnix
 
         if (static_cast<int32_t>(SynchMgrStatusRunning) != lInit)
         {
-            chakra::Logger::error("Unexpected initialization status found "
-                   "in PrepareForShutdown [expected=%d current=%d]\n",
-                   SynchMgrStatusRunning, lInit);
+            chakra::Logger::error(std::format("Unexpected initialization status found "
+                   "in PrepareForShutdown [expected={} current={}]\n",
+                   static_cast<int>(SynchMgrStatusRunning), lInit));
             // We intentionally not set s_lInitStatus to SynchMgrStatusError
             // cause this could interfere with a previous thread already
             // executing shutdown
@@ -1808,16 +1809,16 @@ namespace CorUnix
                     if (1 < iRet)
                     {
                         // Unexpected iRet > 1
-                        fprintf(stderr, "Unexpected return code %d from blocking poll/kevent call\n",
-                                iRet);
+                        chakra::Logger::error(std::format("Unexpected return code {} from blocking poll/kevent call\n",
+                                iRet));
                         goto RBFPP_exit;
                     }
 
                     if (EINTR != iErrno)
                     {
                         // Unexpected error
-                        fprintf(stderr, "Unexpected error from blocking poll/kevent call: %d (%s)\n",
-                               iErrno, strerror(iErrno));
+                        chakra::Logger::error(std::format("Unexpected error from blocking poll/kevent call: {} ({})\n",
+                               iErrno, strerror(iErrno)));
                         goto RBFPP_exit;
                     }
 

--- a/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
@@ -32,6 +32,7 @@ Abstract:
 #include <signal.h>
 #include <errno.h>
 #include <poll.h>
+#include "chakra/Logger.h"
 
 namespace CorUnix
 {
@@ -995,7 +996,7 @@ namespace CorUnix
                 reinterpret_cast<SharedID>(pvSynchData));
             if (NULL == psdSynchData)
             {
-                fprintf(stderr, "Bad shared memory pointer\n");
+                chakra::Logger::error("Bad shared memory pointer\n");
                 goto FOSD_exit;
             }
         }
@@ -1349,7 +1350,7 @@ namespace CorUnix
         }
         else
         {
-            fprintf(stderr, "Multiple PAL Synchronization manager initializations\n");
+            chakra::Logger::error("Multiple PAL Synchronization manager initializations\n");
         }
 
         return pRet;
@@ -1372,7 +1373,7 @@ namespace CorUnix
                                            SynchMgrStatusIdle);
         if (static_cast<int32_t>(SynchMgrStatusIdle) != lInit)
         {
-            fprintf(stderr, "Synchronization Manager already being initialized");
+            chakra::Logger::error("Synchronization Manager already being initialized");
             palErr = ERROR_INTERNAL_ERROR;
             goto I_exit;
         }
@@ -1441,7 +1442,7 @@ namespace CorUnix
 
         if (static_cast<int32_t>(SynchMgrStatusRunning) != lInit)
         {
-            fprintf(stderr, "Unexpected initialization status found "
+            chakra::Logger::error("Unexpected initialization status found "
                    "in PrepareForShutdown [expected=%d current=%d]\n",
                    SynchMgrStatusRunning, lInit);
             // We intentionally not set s_lInitStatus to SynchMgrStatusError
@@ -2196,7 +2197,7 @@ namespace CorUnix
     PAL_ERROR CPalSynchronizationManager::SendMsgToRemoteWorker(
     )
     {
-        fprintf(stderr, "There should never be a reason to send a message to a remote worker\n");
+        chakra::Logger::error("There should never be a reason to send a message to a remote worker\n");
         return ERROR_INTERNAL_ERROR;
     }
 
@@ -2755,7 +2756,7 @@ namespace CorUnix
             poll(NULL, 0, INFTIM);
             sched_yield();
         }
-        fprintf(stderr, "This code should never be executed\n");
+        chakra::Logger::error("This code should never be executed\n");
     }
 
     /*++

--- a/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/synchmanager.cpp
@@ -243,7 +243,7 @@ namespace CorUnix
                     }
                     else
                     {
-                        ASSERT("Unexpected thread wait state %u\n",
+                        fprintf(stderr, "Unexpected thread wait state %u\n",
                                dwWaitState);
                         palErr = ERROR_INTERNAL_ERROR;
                     }
@@ -995,7 +995,7 @@ namespace CorUnix
                 reinterpret_cast<SharedID>(pvSynchData));
             if (NULL == psdSynchData)
             {
-                ASSERT("Bad shared memory pointer\n");
+                fprintf(stderr, "Bad shared memory pointer\n");
                 goto FOSD_exit;
             }
         }
@@ -1349,7 +1349,7 @@ namespace CorUnix
         }
         else
         {
-            ASSERT("Multiple PAL Synchronization manager initializations\n");
+            fprintf(stderr, "Multiple PAL Synchronization manager initializations\n");
         }
 
         return pRet;
@@ -1372,7 +1372,7 @@ namespace CorUnix
                                            SynchMgrStatusIdle);
         if (static_cast<int32_t>(SynchMgrStatusIdle) != lInit)
         {
-            ASSERT("Synchronization Manager already being initialized");
+            fprintf(stderr, "Synchronization Manager already being initialized");
             palErr = ERROR_INTERNAL_ERROR;
             goto I_exit;
         }
@@ -1441,7 +1441,7 @@ namespace CorUnix
 
         if (static_cast<int32_t>(SynchMgrStatusRunning) != lInit)
         {
-            ASSERT("Unexpected initialization status found "
+            fprintf(stderr, "Unexpected initialization status found "
                    "in PrepareForShutdown [expected=%d current=%d]\n",
                    SynchMgrStatusRunning, lInit);
             // We intentionally not set s_lInitStatus to SynchMgrStatusError
@@ -1807,7 +1807,7 @@ namespace CorUnix
                     if (1 < iRet)
                     {
                         // Unexpected iRet > 1
-                        ASSERT("Unexpected return code %d from blocking poll/kevent call\n",
+                        fprintf(stderr, "Unexpected return code %d from blocking poll/kevent call\n",
                                 iRet);
                         goto RBFPP_exit;
                     }
@@ -1815,7 +1815,7 @@ namespace CorUnix
                     if (EINTR != iErrno)
                     {
                         // Unexpected error
-                        ASSERT("Unexpected error from blocking poll/kevent call: %d (%s)\n",
+                        fprintf(stderr, "Unexpected error from blocking poll/kevent call: %d (%s)\n",
                                iErrno, strerror(iErrno));
                         goto RBFPP_exit;
                     }
@@ -2196,7 +2196,7 @@ namespace CorUnix
     PAL_ERROR CPalSynchronizationManager::SendMsgToRemoteWorker(
     )
     {
-        ASSERT("There should never be a reason to send a message to a remote worker\n");
+        fprintf(stderr, "There should never be a reason to send a message to a remote worker\n");
         return ERROR_INTERNAL_ERROR;
     }
 
@@ -2755,7 +2755,7 @@ namespace CorUnix
             poll(NULL, 0, INFTIM);
             sched_yield();
         }
-        ASSERT("This code should never be executed\n");
+        fprintf(stderr, "This code should never be executed\n");
     }
 
     /*++

--- a/chakracore-cxx/pal/src/synchmgr/wait.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/wait.cpp
@@ -26,6 +26,7 @@ Revision History:
 #include "pal/synchobjects.hpp"
 #include <new>
 #include "pal/dbgmsg.h"
+#include "chakra/Logger.h"
 
 SET_DEFAULT_DEBUG_CHANNEL(SYNC);
 
@@ -308,7 +309,7 @@ uint32_t CorUnix::InternalWaitForMultipleObjectsEx(
             }
             else
             {
-                fprintf(stderr, "Awakened for APC, but no APC is pending\n");
+                chakra::Logger::error("Awakened for APC, but no APC is pending\n");
                 pThread->SetLastError(ERROR_INTERNAL_ERROR);
                 dwRet = WAIT_FAILED;
             }

--- a/chakracore-cxx/pal/src/synchmgr/wait.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/wait.cpp
@@ -27,6 +27,7 @@ Revision History:
 #include <new>
 #include "pal/dbgmsg.h"
 #include "chakra/Logger.h"
+#include <format>
 
 SET_DEFAULT_DEBUG_CHANNEL(SYNC);
 
@@ -565,8 +566,8 @@ PAL_ERROR CorUnix::InternalSleepEx (
                         "Awakened for APC, but no APC is pending\n");
             break;
         case MutexAbondoned:
-            fprintf(stderr, "Thread %p awakened with reason=MutexAbondoned from a "
-                   "SleepEx\n", pThread);
+            chakra::Logger::error(std::format("Thread {} awakened with reason=MutexAbondoned from a "
+                   "SleepEx\n", static_cast<void *>(pThread)));
             palErr = ERROR_INTERNAL_ERROR;
             break;
         case WaitFailed:

--- a/chakracore-cxx/pal/src/synchmgr/wait.cpp
+++ b/chakracore-cxx/pal/src/synchmgr/wait.cpp
@@ -308,7 +308,7 @@ uint32_t CorUnix::InternalWaitForMultipleObjectsEx(
             }
             else
             {
-                ASSERT("Awakened for APC, but no APC is pending\n");
+                fprintf(stderr, "Awakened for APC, but no APC is pending\n");
                 pThread->SetLastError(ERROR_INTERNAL_ERROR);
                 dwRet = WAIT_FAILED;
             }
@@ -564,7 +564,7 @@ PAL_ERROR CorUnix::InternalSleepEx (
                         "Awakened for APC, but no APC is pending\n");
             break;
         case MutexAbondoned:
-            ASSERT("Thread %p awakened with reason=MutexAbondoned from a "
+            fprintf(stderr, "Thread %p awakened with reason=MutexAbondoned from a "
                    "SleepEx\n", pThread);
             palErr = ERROR_INTERNAL_ERROR;
             break;

--- a/chakracore-cxx/pal/src/synchobj/event.cpp
+++ b/chakracore-cxx/pal/src/synchobj/event.cpp
@@ -154,7 +154,7 @@ CorUnix::InternalCreateEvent(
 
     if (lpName != nullptr)
     {
-        ASSERT("lpName: Cross-process named objects are not supported in PAL");
+        fprintf(stderr, "lpName: Cross-process named objects are not supported in PAL");
         palError = ERROR_NOT_SUPPORTED;
         goto InternalCreateEventExit;
     }
@@ -188,7 +188,7 @@ CorUnix::InternalCreateEvent(
 
         if (NO_ERROR != palError)
         {
-            ASSERT("Unable to set new event state (%d)\n", palError);
+            fprintf(stderr, "Unable to set new event state (%d)\n", palError);
             goto InternalCreateEventExit;
         }
     }
@@ -326,7 +326,7 @@ CorUnix::InternalSetEvent(
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Error %d obtaining synch state controller\n", palError);
+        fprintf(stderr, "Error %d obtaining synch state controller\n", palError);
         goto InternalSetEventExit;
     }
 
@@ -334,7 +334,7 @@ CorUnix::InternalSetEvent(
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Error %d setting event state\n", palError);
+        fprintf(stderr, "Error %d setting event state\n", palError);
         goto InternalSetEventExit;
     }
 

--- a/chakracore-cxx/pal/src/synchobj/event.cpp
+++ b/chakracore-cxx/pal/src/synchobj/event.cpp
@@ -25,6 +25,7 @@ Revision History:
 #include "pal/thread.hpp"
 #include "pal/dbgmsg.h"
 #include "chakra/Logger.h"
+#include <format>
 
 using namespace CorUnix;
 
@@ -189,7 +190,7 @@ CorUnix::InternalCreateEvent(
 
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Unable to set new event state (%d)\n", palError);
+            chakra::Logger::error(std::format("Unable to set new event state ({})\n", palError));
             goto InternalCreateEventExit;
         }
     }
@@ -327,7 +328,7 @@ CorUnix::InternalSetEvent(
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Error %d obtaining synch state controller\n", palError);
+        chakra::Logger::error(std::format("Error {} obtaining synch state controller\n", palError));
         goto InternalSetEventExit;
     }
 
@@ -335,7 +336,7 @@ CorUnix::InternalSetEvent(
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Error %d setting event state\n", palError);
+        chakra::Logger::error(std::format("Error {} setting event state\n", palError));
         goto InternalSetEventExit;
     }
 

--- a/chakracore-cxx/pal/src/synchobj/event.cpp
+++ b/chakracore-cxx/pal/src/synchobj/event.cpp
@@ -24,6 +24,7 @@ Revision History:
 #include "pal/event.hpp"
 #include "pal/thread.hpp"
 #include "pal/dbgmsg.h"
+#include "chakra/Logger.h"
 
 using namespace CorUnix;
 
@@ -154,7 +155,7 @@ CorUnix::InternalCreateEvent(
 
     if (lpName != nullptr)
     {
-        fprintf(stderr, "lpName: Cross-process named objects are not supported in PAL");
+        chakra::Logger::error("lpName: Cross-process named objects are not supported in PAL");
         palError = ERROR_NOT_SUPPORTED;
         goto InternalCreateEventExit;
     }

--- a/chakracore-cxx/pal/src/thread/context.cpp
+++ b/chakracore-cxx/pal/src/thread/context.cpp
@@ -731,7 +731,7 @@ CONTEXT_GetThreadContextFromPort(
         MachRet = thread_get_state(Port, StateFlavor, reinterpret_cast<thread_state_t>(&State), &StateCount);
         if (MachRet != KERN_SUCCESS)
         {
-            ASSERT("thread_get_state(THREAD_STATE) failed: %d\n", MachRet);
+            fprintf(stderr, "thread_get_state(THREAD_STATE) failed: %d\n", MachRet);
             goto exit;
         }
 
@@ -929,7 +929,7 @@ CONTEXT_GetThreadContextFromThreadState(
 #endif
 
         default:
-            ASSERT("Invalid thread state flavor %d\n", threadStateFlavor);
+            fprintf(stderr, "Invalid thread state flavor %d\n", threadStateFlavor);
             break;
     }
 }

--- a/chakracore-cxx/pal/src/thread/context.cpp
+++ b/chakracore-cxx/pal/src/thread/context.cpp
@@ -28,6 +28,8 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include "pal/thread.hpp"
 #include "pal/utils.h"
 #include "pal/virtual.h"
+#include "chakra/Logger.h"
+#include <format>
 
 #include <errno.h>
 #include <unistd.h>
@@ -731,7 +733,7 @@ CONTEXT_GetThreadContextFromPort(
         MachRet = thread_get_state(Port, StateFlavor, reinterpret_cast<thread_state_t>(&State), &StateCount);
         if (MachRet != KERN_SUCCESS)
         {
-            fprintf(stderr, "thread_get_state(THREAD_STATE) failed: %d\n", MachRet);
+            chakra::Logger::error(std::format("thread_get_state(THREAD_STATE) failed: {}\n", MachRet));
             goto exit;
         }
 
@@ -929,7 +931,7 @@ CONTEXT_GetThreadContextFromThreadState(
 #endif
 
         default:
-            fprintf(stderr, "Invalid thread state flavor %d\n", threadStateFlavor);
+            chakra::Logger::error(std::format("Invalid thread state flavor {}\n", threadStateFlavor));
             break;
     }
 }

--- a/chakracore-cxx/pal/src/thread/pal_thread.cpp
+++ b/chakracore-cxx/pal/src/thread/pal_thread.cpp
@@ -41,6 +41,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include "pal/utils.h"
 #include "pal/virtual.h"
 #include "chakra/Logger.h"
+#include <format>
 
 #if defined(__NetBSD__) && !defined(__linux__)
 #include <sys/cdefs.h>
@@ -418,8 +419,8 @@ CorUnix::InternalCreateThread(
     /* Validate parameters */
     if (lpThreadAttributes != NULL)
     {
-        fprintf(stderr, "lpThreadAttributes parameter must be NULL (%p)\n",
-               lpThreadAttributes);
+        chakra::Logger::error(std::format("lpThreadAttributes parameter must be NULL ({})\n",
+               static_cast<void *>(lpThreadAttributes)));
         palError = ERROR_INVALID_PARAMETER;
         goto EXIT;
     }
@@ -429,7 +430,7 @@ CorUnix::InternalCreateThread(
 
     if ((dwCreationFlags != 0) && (dwCreationFlags != CREATE_SUSPENDED))
     {
-        fprintf(stderr, "dwCreationFlags parameter is invalid (%#x)\n", dwCreationFlags);
+        chakra::Logger::error(std::format("dwCreationFlags parameter is invalid ({:#x})\n", dwCreationFlags));
         palError = ERROR_INVALID_PARAMETER;
         goto EXIT;
     }
@@ -832,7 +833,7 @@ CorUnix::InternalSetThreadPriority(
         break;
 
     default:
-        fprintf(stderr, "Priority %d not supported\n", iNewPriority);
+        chakra::Logger::error(std::format("Priority {} not supported\n", iNewPriority));
         palError = ERROR_INVALID_PARAMETER;
         goto InternalSetThreadPriorityExit;
     }
@@ -874,8 +875,8 @@ CorUnix::InternalSetThreadPriority(
     min_priority = sched_get_priority_min(policy);
     if( -1 == max_priority || -1 == min_priority)
     {
-        fprintf(stderr, "sched_get_priority_min/max failed; error is %d (%s)\n",
-               errno, strerror(errno));
+        chakra::Logger::error(std::format("sched_get_priority_min/max failed; error is {} ({})\n",
+               errno, strerror(errno)));
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
@@ -922,7 +923,7 @@ CorUnix::InternalSetThreadPriority(
     st = pthread_setschedparam(pTargetThread->GetPThreadSelf(), policy, &schedParam);
     if (st != 0)
     {
-        fprintf(stderr, "Unable to set thread priority to %d (error %d)\n", static_cast<int>(posix_priority), st);
+        chakra::Logger::error(std::format("Unable to set thread priority to {} (error {})\n", static_cast<int>(posix_priority), st));
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
@@ -974,8 +975,8 @@ CorUnix::GetThreadTimesInternal(
 
     if (palError != NO_ERROR)
     {
-        fprintf(stderr, "Unable to get thread data from handle %p"
-              "thread\n", hThread);
+        chakra::Logger::error(std::format("Unable to get thread data from handle {}"
+              "thread\n", hThread));
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
     }
@@ -1042,8 +1043,8 @@ CorUnix::GetThreadTimesInternal(
     );
     if (palError != NO_ERROR)
     {
-        fprintf(stderr, "Unable to get thread data from handle %p"
-              "thread\n", hThread);
+        chakra::Logger::error(std::format("Unable to get thread data from handle {}"
+              "thread\n", hThread));
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
     }
@@ -1062,7 +1063,7 @@ CorUnix::GetThreadTimesInternal(
     if (klwp == NULL || nlwps < 1)
     {
         kvm_close(kd);
-        fprintf(stderr, "Unable to get clock from %p thread\n", hThread);
+        chakra::Logger::error(std::format("Unable to get clock from {} thread\n", hThread));
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1080,7 +1081,7 @@ CorUnix::GetThreadTimesInternal(
     if (!found)
     {
         kvm_close(kd);
-        fprintf(stderr, "Unable to get clock from %p thread\n", hThread);
+        chakra::Logger::error(std::format("Unable to get clock from {} thread\n", hThread));
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1124,8 +1125,8 @@ CorUnix::GetThreadTimesInternal(
     );
     if (palError != NO_ERROR)
     {
-        fprintf(stderr, "Unable to get thread data from handle %p"
-              "thread\n", hThread);
+        chakra::Logger::error(std::format("Unable to get thread data from handle {}"
+              "thread\n", hThread));
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
     }
@@ -1144,7 +1145,7 @@ CorUnix::GetThreadTimesInternal(
     struct timespec ts;
     if (clock_gettime(cid, &ts) != 0)
     {
-        fprintf(stderr, "clock_gettime() failed; errno is %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("clock_gettime() failed; errno is {} ({})\n", errno, strerror(errno)));
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1157,7 +1158,7 @@ CorUnix::GetThreadTimesInternal(
     fd = open(statusFilename, O_RDONLY);
     if (fd == -1)
     {
-       fprintf(stderr, "open(%s) failed; errno is %d (%s)\n", statusFilename, errno, strerror(errno));
+       chakra::Logger::error(std::format("open({}) failed; errno is {} ({})\n", statusFilename, errno, strerror(errno)));
        SetLastError(ERROR_INTERNAL_ERROR);
        pTargetThread->Unlock(pThread);
        goto SetTimesToZero;
@@ -1229,7 +1230,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
     palError = pThread->RunPostCreateInitializers();
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Error %i initializing thread data (post creation)\n", palError);
+        chakra::Logger::error(std::format("Error {} initializing thread data (post creation)\n", palError));
         goto fail;
     }
 
@@ -1239,7 +1240,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
         palError = pThread->suspensionInfo.InternalSuspendNewThreadFromData(pThread);
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Error %i attempting to suspend new thread\n", palError);
+            chakra::Logger::error(std::format("Error {} attempting to suspend new thread\n", palError));
             goto fail;
         }
 

--- a/chakracore-cxx/pal/src/thread/pal_thread.cpp
+++ b/chakracore-cxx/pal/src/thread/pal_thread.cpp
@@ -40,6 +40,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include "pal/init.h"
 #include "pal/utils.h"
 #include "pal/virtual.h"
+#include "chakra/Logger.h"
 
 #if defined(__NetBSD__) && !defined(__linux__)
 #include <sys/cdefs.h>
@@ -578,7 +579,7 @@ ExitThread(
     /* kill the thread (itself), resulting in a call to InternalEndCurrentThread */
     pthread_exit(NULL);
 
-    fprintf(stderr, "pthread_exit should not return!\n");
+    chakra::Logger::error("pthread_exit should not return!\n");
     while (true);
 }
 
@@ -636,14 +637,14 @@ CorUnix::InternalEndCurrentThread(
         palError = pSynchStateController->SetSignalCount(1);
         if (NO_ERROR != palError)
         {
-            fprintf(stderr, "Unable to mark thread object as signaled");
+            chakra::Logger::error("Unable to mark thread object as signaled");
         }
 
         pSynchStateController->ReleaseController();
     }
     else
     {
-        fprintf(stderr, "Unable to obtain state controller for thread");
+        chakra::Logger::error("Unable to obtain state controller for thread");
     }
 
     //
@@ -853,7 +854,7 @@ CorUnix::InternalSetThreadPriority(
             &schedParam
             ) != 0)
     {
-        fprintf(stderr, "Unable to get current thread scheduling information\n");
+        chakra::Logger::error("Unable to get current thread scheduling information\n");
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
@@ -995,7 +996,7 @@ CorUnix::GetThreadTimesInternal(
 
     if (status != KERN_SUCCESS)
     {
-        fprintf(stderr, "Unable to get resource usage information for the current "
+        chakra::Logger::error("Unable to get resource usage information for the current "
               "thread\n");
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
@@ -1050,7 +1051,7 @@ CorUnix::GetThreadTimesInternal(
     kd = kvm_open(NULL, NULL, NULL, KVM_NO_FILES, "kvm_open");
     if (kd == NULL)
     {
-        fprintf(stderr, "kvm_open(3) error");
+        chakra::Logger::error("kvm_open(3) error");
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
     }
@@ -1134,7 +1135,7 @@ CorUnix::GetThreadTimesInternal(
 #if defined(__linux__)
     if (pthread_getcpuclockid(pTargetThread->GetPThreadSelf(), &cid) != 0)
     {
-        fprintf(stderr, "Unable to get clock from thread\n", hThread);
+        chakra::Logger::error("Unable to get clock from thread\n");
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1214,7 +1215,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
 
     if (nullptr == pThread)
     {
-        fprintf(stderr, "THREAD pointer is NULL!\n");
+        chakra::Logger::error("THREAD pointer is NULL!\n");
         goto fail;
     }
 
@@ -1271,7 +1272,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
     ExitThread(retValue);
 
     /* Note: never get here */
-    fprintf(stderr, "ExitThread failed!\n");
+    chakra::Logger::error("ExitThread failed!\n");
     for (;;);
 
 fail:
@@ -1801,7 +1802,7 @@ CPalThread::RunPostCreateInitializers(
 
     if (pthread_setspecific(thObjKey, this))
     {
-        fprintf(stderr, "Unable to set the thread object key's value\n");
+        chakra::Logger::error("Unable to set the thread object key's value\n");
         palError = ERROR_INTERNAL_ERROR;
         goto RunPostCreateInitializersExit;
     }
@@ -1845,7 +1846,7 @@ CPalThread::SetStartStatus(
 #if _DEBUG
     if (m_fStartStatusSet)
     {
-        fprintf(stderr, "Multiple calls to CPalThread::SetStartStatus\n");
+        chakra::Logger::error("Multiple calls to CPalThread::SetStartStatus\n");
     }
 #endif
 
@@ -1862,7 +1863,7 @@ CPalThread::SetStartStatus(
     iError = pthread_mutex_lock(&m_startMutex);
     if (0 != iError)
     {
-        fprintf(stderr, "pthread primitive failure\n");
+        chakra::Logger::error("pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1872,14 +1873,14 @@ CPalThread::SetStartStatus(
     iError = pthread_cond_signal(&m_startCond);
     if (0 != iError)
     {
-        fprintf(stderr, "pthread primitive failure\n");
+        chakra::Logger::error("pthread primitive failure\n");
         // bugcheck?
     }
 
     iError = pthread_mutex_unlock(&m_startMutex);
     if (0 != iError)
     {
-        fprintf(stderr, "pthread primitive failure\n");
+        chakra::Logger::error("pthread primitive failure\n");
         // bugcheck?
     }
 }
@@ -1894,7 +1895,7 @@ CPalThread::WaitForStartStatus(
     iError = pthread_mutex_lock(&m_startMutex);
     if (0 != iError)
     {
-        fprintf(stderr, "pthread primitive failure\n");
+        chakra::Logger::error("pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1903,7 +1904,7 @@ CPalThread::WaitForStartStatus(
         iError = pthread_cond_wait(&m_startCond, &m_startMutex);
         if (0 != iError)
         {
-            fprintf(stderr, "pthread primitive failure\n");
+            chakra::Logger::error("pthread primitive failure\n");
             // bugcheck?
         }
     }
@@ -1911,7 +1912,7 @@ CPalThread::WaitForStartStatus(
     iError = pthread_mutex_unlock(&m_startMutex);
     if (0 != iError)
     {
-        fprintf(stderr, "pthread primitive failure\n");
+        chakra::Logger::error("pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1955,7 +1956,7 @@ void ThreadCleanupRoutine(CPalThread *pThread, IPalObject *pObjectToCleanup, boo
     }
     else
     {
-        fprintf(stderr, "Unable to obtain thread data");
+        chakra::Logger::error("Unable to obtain thread data");
     }
 
 }

--- a/chakracore-cxx/pal/src/thread/pal_thread.cpp
+++ b/chakracore-cxx/pal/src/thread/pal_thread.cpp
@@ -417,7 +417,7 @@ CorUnix::InternalCreateThread(
     /* Validate parameters */
     if (lpThreadAttributes != NULL)
     {
-        ASSERT("lpThreadAttributes parameter must be NULL (%p)\n",
+        fprintf(stderr, "lpThreadAttributes parameter must be NULL (%p)\n",
                lpThreadAttributes);
         palError = ERROR_INVALID_PARAMETER;
         goto EXIT;
@@ -428,7 +428,7 @@ CorUnix::InternalCreateThread(
 
     if ((dwCreationFlags != 0) && (dwCreationFlags != CREATE_SUSPENDED))
     {
-        ASSERT("dwCreationFlags parameter is invalid (%#x)\n", dwCreationFlags);
+        fprintf(stderr, "dwCreationFlags parameter is invalid (%#x)\n", dwCreationFlags);
         palError = ERROR_INVALID_PARAMETER;
         goto EXIT;
     }
@@ -578,7 +578,7 @@ ExitThread(
     /* kill the thread (itself), resulting in a call to InternalEndCurrentThread */
     pthread_exit(NULL);
 
-    ASSERT("pthread_exit should not return!\n");
+    fprintf(stderr, "pthread_exit should not return!\n");
     while (true);
 }
 
@@ -636,14 +636,14 @@ CorUnix::InternalEndCurrentThread(
         palError = pSynchStateController->SetSignalCount(1);
         if (NO_ERROR != palError)
         {
-            ASSERT("Unable to mark thread object as signaled");
+            fprintf(stderr, "Unable to mark thread object as signaled");
         }
 
         pSynchStateController->ReleaseController();
     }
     else
     {
-        ASSERT("Unable to obtain state controller for thread");
+        fprintf(stderr, "Unable to obtain state controller for thread");
     }
 
     //
@@ -831,7 +831,7 @@ CorUnix::InternalSetThreadPriority(
         break;
 
     default:
-        ASSERT("Priority %d not supported\n", iNewPriority);
+        fprintf(stderr, "Priority %d not supported\n", iNewPriority);
         palError = ERROR_INVALID_PARAMETER;
         goto InternalSetThreadPriorityExit;
     }
@@ -853,7 +853,7 @@ CorUnix::InternalSetThreadPriority(
             &schedParam
             ) != 0)
     {
-        ASSERT("Unable to get current thread scheduling information\n");
+        fprintf(stderr, "Unable to get current thread scheduling information\n");
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
@@ -873,7 +873,7 @@ CorUnix::InternalSetThreadPriority(
     min_priority = sched_get_priority_min(policy);
     if( -1 == max_priority || -1 == min_priority)
     {
-        ASSERT("sched_get_priority_min/max failed; error is %d (%s)\n",
+        fprintf(stderr, "sched_get_priority_min/max failed; error is %d (%s)\n",
                errno, strerror(errno));
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
@@ -921,7 +921,7 @@ CorUnix::InternalSetThreadPriority(
     st = pthread_setschedparam(pTargetThread->GetPThreadSelf(), policy, &schedParam);
     if (st != 0)
     {
-        ASSERT("Unable to set thread priority to %d (error %d)\n", static_cast<int>(posix_priority), st);
+        fprintf(stderr, "Unable to set thread priority to %d (error %d)\n", static_cast<int>(posix_priority), st);
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
@@ -973,7 +973,7 @@ CorUnix::GetThreadTimesInternal(
 
     if (palError != NO_ERROR)
     {
-        ASSERT("Unable to get thread data from handle %p"
+        fprintf(stderr, "Unable to get thread data from handle %p"
               "thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
@@ -995,7 +995,7 @@ CorUnix::GetThreadTimesInternal(
 
     if (status != KERN_SUCCESS)
     {
-        ASSERT("Unable to get resource usage information for the current "
+        fprintf(stderr, "Unable to get resource usage information for the current "
               "thread\n");
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
@@ -1041,7 +1041,7 @@ CorUnix::GetThreadTimesInternal(
     );
     if (palError != NO_ERROR)
     {
-        ASSERT("Unable to get thread data from handle %p"
+        fprintf(stderr, "Unable to get thread data from handle %p"
               "thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
@@ -1050,7 +1050,7 @@ CorUnix::GetThreadTimesInternal(
     kd = kvm_open(NULL, NULL, NULL, KVM_NO_FILES, "kvm_open");
     if (kd == NULL)
     {
-        ASSERT("kvm_open(3) error");
+        fprintf(stderr, "kvm_open(3) error");
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
     }
@@ -1061,7 +1061,7 @@ CorUnix::GetThreadTimesInternal(
     if (klwp == NULL || nlwps < 1)
     {
         kvm_close(kd);
-        ASSERT("Unable to get clock from %p thread\n", hThread);
+        fprintf(stderr, "Unable to get clock from %p thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1079,7 +1079,7 @@ CorUnix::GetThreadTimesInternal(
     if (!found)
     {
         kvm_close(kd);
-        ASSERT("Unable to get clock from %p thread\n", hThread);
+        fprintf(stderr, "Unable to get clock from %p thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1123,7 +1123,7 @@ CorUnix::GetThreadTimesInternal(
     );
     if (palError != NO_ERROR)
     {
-        ASSERT("Unable to get thread data from handle %p"
+        fprintf(stderr, "Unable to get thread data from handle %p"
               "thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
@@ -1134,7 +1134,7 @@ CorUnix::GetThreadTimesInternal(
 #if defined(__linux__)
     if (pthread_getcpuclockid(pTargetThread->GetPThreadSelf(), &cid) != 0)
     {
-        ASSERT("Unable to get clock from thread\n", hThread);
+        fprintf(stderr, "Unable to get clock from thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1143,7 +1143,7 @@ CorUnix::GetThreadTimesInternal(
     struct timespec ts;
     if (clock_gettime(cid, &ts) != 0)
     {
-        ASSERT("clock_gettime() failed; errno is %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "clock_gettime() failed; errno is %d (%s)\n", errno, strerror(errno));
         SetLastError(ERROR_INTERNAL_ERROR);
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
@@ -1156,7 +1156,7 @@ CorUnix::GetThreadTimesInternal(
     fd = open(statusFilename, O_RDONLY);
     if (fd == -1)
     {
-       ASSERT("open(%s) failed; errno is %d (%s)\n", statusFilename, errno, strerror(errno));
+       fprintf(stderr, "open(%s) failed; errno is %d (%s)\n", statusFilename, errno, strerror(errno));
        SetLastError(ERROR_INTERNAL_ERROR);
        pTargetThread->Unlock(pThread);
        goto SetTimesToZero;
@@ -1214,7 +1214,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
 
     if (nullptr == pThread)
     {
-        ASSERT("THREAD pointer is NULL!\n");
+        fprintf(stderr, "THREAD pointer is NULL!\n");
         goto fail;
     }
 
@@ -1228,7 +1228,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
     palError = pThread->RunPostCreateInitializers();
     if (NO_ERROR != palError)
     {
-        ASSERT("Error %i initializing thread data (post creation)\n", palError);
+        fprintf(stderr, "Error %i initializing thread data (post creation)\n", palError);
         goto fail;
     }
 
@@ -1238,7 +1238,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
         palError = pThread->suspensionInfo.InternalSuspendNewThreadFromData(pThread);
         if (NO_ERROR != palError)
         {
-            ASSERT("Error %i attempting to suspend new thread\n", palError);
+            fprintf(stderr, "Error %i attempting to suspend new thread\n", palError);
             goto fail;
         }
 
@@ -1271,7 +1271,7 @@ void *CPalThread::ThreadEntry(CPalThread *pThread)
     ExitThread(retValue);
 
     /* Note: never get here */
-    ASSERT("ExitThread failed!\n");
+    fprintf(stderr, "ExitThread failed!\n");
     for (;;);
 
 fail:
@@ -1801,7 +1801,7 @@ CPalThread::RunPostCreateInitializers(
 
     if (pthread_setspecific(thObjKey, this))
     {
-        ASSERT("Unable to set the thread object key's value\n");
+        fprintf(stderr, "Unable to set the thread object key's value\n");
         palError = ERROR_INTERNAL_ERROR;
         goto RunPostCreateInitializersExit;
     }
@@ -1845,7 +1845,7 @@ CPalThread::SetStartStatus(
 #if _DEBUG
     if (m_fStartStatusSet)
     {
-        ASSERT("Multiple calls to CPalThread::SetStartStatus\n");
+        fprintf(stderr, "Multiple calls to CPalThread::SetStartStatus\n");
     }
 #endif
 
@@ -1862,7 +1862,7 @@ CPalThread::SetStartStatus(
     iError = pthread_mutex_lock(&m_startMutex);
     if (0 != iError)
     {
-        ASSERT("pthread primitive failure\n");
+        fprintf(stderr, "pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1872,14 +1872,14 @@ CPalThread::SetStartStatus(
     iError = pthread_cond_signal(&m_startCond);
     if (0 != iError)
     {
-        ASSERT("pthread primitive failure\n");
+        fprintf(stderr, "pthread primitive failure\n");
         // bugcheck?
     }
 
     iError = pthread_mutex_unlock(&m_startMutex);
     if (0 != iError)
     {
-        ASSERT("pthread primitive failure\n");
+        fprintf(stderr, "pthread primitive failure\n");
         // bugcheck?
     }
 }
@@ -1894,7 +1894,7 @@ CPalThread::WaitForStartStatus(
     iError = pthread_mutex_lock(&m_startMutex);
     if (0 != iError)
     {
-        ASSERT("pthread primitive failure\n");
+        fprintf(stderr, "pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1903,7 +1903,7 @@ CPalThread::WaitForStartStatus(
         iError = pthread_cond_wait(&m_startCond, &m_startMutex);
         if (0 != iError)
         {
-            ASSERT("pthread primitive failure\n");
+            fprintf(stderr, "pthread primitive failure\n");
             // bugcheck?
         }
     }
@@ -1911,7 +1911,7 @@ CPalThread::WaitForStartStatus(
     iError = pthread_mutex_unlock(&m_startMutex);
     if (0 != iError)
     {
-        ASSERT("pthread primitive failure\n");
+        fprintf(stderr, "pthread primitive failure\n");
         // bugcheck?
     }
 
@@ -1955,7 +1955,7 @@ void ThreadCleanupRoutine(CPalThread *pThread, IPalObject *pObjectToCleanup, boo
     }
     else
     {
-        ASSERT("Unable to obtain thread data");
+        fprintf(stderr, "Unable to obtain thread data");
     }
 
 }

--- a/chakracore-cxx/pal/src/thread/process.cpp
+++ b/chakracore-cxx/pal/src/thread/process.cpp
@@ -35,6 +35,7 @@ SET_DEFAULT_DEBUG_CHANNEL(PROCESS); // some headers have code with asserts, so d
 #include "pal/misc.h"
 #include "pal/virtual.h"
 #include "pal/stackstring.hpp"
+#include "chakra/Logger.h"
 
 #include <errno.h>
 #include <poll.h>
@@ -267,7 +268,7 @@ PrepareStandardHandle(
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Unable to access file data\n");
+        chakra::Logger::error("Unable to access file data\n");
         goto PrepareStandardHandleExit;
     }
 
@@ -606,7 +607,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Unable to access local data");
+        chakra::Logger::error("Unable to access local data");
         goto CreateInitialProcessAndThreadObjectsExit;
     }
 
@@ -632,7 +633,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
 
     if (NO_ERROR != palError)
     {
-        fprintf(stderr, "Failure registering process object");
+        chakra::Logger::error("Failure registering process object");
         goto CreateInitialProcessAndThreadObjectsExit;
     }
 
@@ -714,7 +715,7 @@ CorUnix::PROCRemoveThread(
     /* if thread list is empty */
     if (curThread == NULL)
     {
-        fprintf(stderr, "Thread list is empty.\n");
+        chakra::Logger::error("Thread list is empty.\n");
         goto EXIT;
     }
 

--- a/chakracore-cxx/pal/src/thread/process.cpp
+++ b/chakracore-cxx/pal/src/thread/process.cpp
@@ -267,7 +267,7 @@ PrepareStandardHandle(
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Unable to access file data\n");
+        fprintf(stderr, "Unable to access file data\n");
         goto PrepareStandardHandleExit;
     }
 
@@ -379,7 +379,7 @@ static BOOL PROCEndProcess(HANDLE hProcess, uint32_t uExitCode, BOOL bTerminateU
                 break;
             default:
                 // Unexpected failure.
-                ASSERT(FALSE);
+                assert(false);
                 SetLastError(ERROR_INTERNAL_ERROR);
                 break;
             }
@@ -422,7 +422,7 @@ static BOOL PROCEndProcess(HANDLE hProcess, uint32_t uExitCode, BOOL bTerminateU
             exit(uExitCode);
         }
 
-        ASSERT(FALSE); // we shouldn't get here
+        assert(false); // we shouldn't get here
     }
 
     return ret;
@@ -606,7 +606,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Unable to access local data");
+        fprintf(stderr, "Unable to access local data");
         goto CreateInitialProcessAndThreadObjectsExit;
     }
 
@@ -632,7 +632,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
 
     if (NO_ERROR != palError)
     {
-        ASSERT("Failure registering process object");
+        fprintf(stderr, "Failure registering process object");
         goto CreateInitialProcessAndThreadObjectsExit;
     }
 
@@ -714,7 +714,7 @@ CorUnix::PROCRemoveThread(
     /* if thread list is empty */
     if (curThread == NULL)
     {
-        ASSERT("Thread list is empty.\n");
+        fprintf(stderr, "Thread list is empty.\n");
         goto EXIT;
     }
 
@@ -1066,7 +1066,7 @@ PROCGetProcessStatus(
         }
         else
         {
-            ASSERT("waitpid returned unexpected value %d\n",wait_retval);
+            fprintf(stderr, "waitpid returned unexpected value %d\n",wait_retval);
             *pdwExitCode = EXIT_FAILURE;
             *pps = PS_DONE;
         }

--- a/chakracore-cxx/pal/src/thread/process.cpp
+++ b/chakracore-cxx/pal/src/thread/process.cpp
@@ -448,17 +448,6 @@ void PROCCleanupProcess()
     PALShutdown();
 }
 
-#define FATAL_ASSERT(e, msg) \
-    do \
-    { \
-        if (!(e)) \
-        { \
-            fprintf(stderr, "FATAL ERROR: " msg); \
-            abort(); \
-        } \
-    } \
-    while(0)
-
 /*++
 Function:
   PROCGetProcessIDFromHandle

--- a/chakracore-cxx/pal/src/thread/process.cpp
+++ b/chakracore-cxx/pal/src/thread/process.cpp
@@ -39,6 +39,7 @@ SET_DEFAULT_DEBUG_CHANNEL(PROCESS); // some headers have code with asserts, so d
 
 #include <errno.h>
 #include <poll.h>
+#include <format>
 
 #include <unistd.h>
 #include <sys/mman.h>
@@ -1067,7 +1068,7 @@ PROCGetProcessStatus(
         }
         else
         {
-            fprintf(stderr, "waitpid returned unexpected value %d\n",wait_retval);
+            chakra::Logger::error(std::format("waitpid returned unexpected value {}\n",wait_retval));
             *pdwExitCode = EXIT_FAILURE;
             *pps = PS_DONE;
         }

--- a/chakracore-cxx/pal/src/thread/threadsusp.cpp
+++ b/chakracore-cxx/pal/src/thread/threadsusp.cpp
@@ -34,6 +34,7 @@ Revision History:
 #include <sys/stat.h>
 #include <limits.h>
 #include <debugmacrosext.h>
+#include "chakra/Logger.h"
 
 #if defined(_AIX)
 // AIX requires explicit definition of the union semun (see semctl man page)
@@ -229,7 +230,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
 
     if (SignalHandlerThread == pthrTarget->GetThreadType())
     {
-        fprintf(stderr, "Attempting to resume the signal handling thread, which can never be suspended.\n");
+        chakra::Logger::error("Attempting to resume the signal handling thread, which can never be suspended.\n");
         palError = ERROR_INVALID_HANDLE;
         goto InternalResumeThreadFromDataExit;
     }
@@ -800,7 +801,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     if (m_nSemsuspid == m_nSemrespid)
     {
-        fprintf(stderr, "Suspension and Resumption Semaphores have the same id\n");
+        chakra::Logger::error("Suspension and Resumption Semaphores have the same id\n");
         goto InitializePreCreateExit;
     }
 

--- a/chakracore-cxx/pal/src/thread/threadsusp.cpp
+++ b/chakracore-cxx/pal/src/thread/threadsusp.cpp
@@ -229,7 +229,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
 
     if (SignalHandlerThread == pthrTarget->GetThreadType())
     {
-        ASSERT("Attempting to resume the signal handling thread, which can never be suspended.\n");
+        fprintf(stderr, "Attempting to resume the signal handling thread, which can never be suspended.\n");
         palError = ERROR_INVALID_HANDLE;
         goto InternalResumeThreadFromDataExit;
     }
@@ -289,7 +289,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
                 // Some other error occurred; need to release suspension mutexes before leaving ResumeThread.
                 palError = ERROR_INTERNAL_ERROR;
                 ReleaseSuspensionLocks(pthrResumer, pthrTarget);
-                ASSERT("Write() failed; error is %d (%s)\n", errno, strerror(errno));
+                fprintf(stderr, "Write() failed; error is %d (%s)\n", errno, strerror(errno));
                 goto InternalResumeThreadFromDataExit;
             }
         }
@@ -515,12 +515,12 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
 #if USE_POSIX_SEMAPHORES
     if (sem_post(&m_semSusp) == -1)
     {
-        ASSERT("sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_SYSV_SEMAPHORES
     if (semop(m_nSemsuspid, &m_sbSempost, 1) == -1)
     {
-        ASSERT("semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -539,7 +539,7 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
     status = pthread_mutex_lock(&m_mutexSusp);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
     }
 
     m_fSuspended = TRUE;
@@ -547,13 +547,13 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
     status = pthread_cond_signal(&m_condSusp);
     if (status != 0)
     {
-        ASSERT("pthread_cond_signal returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_cond_signal returned %d (%s)\n", status, strerror(status));
     }
 
     status = pthread_mutex_unlock(&m_mutexSusp);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -571,12 +571,12 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
 #if USE_POSIX_SEMAPHORES
     while (sem_wait(&m_semSusp) == -1)
     {
-        ASSERT("sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_SYSV_SEMAPHORES
     while (semop(m_nSemsuspid, &m_sbSemwait, 1) == -1)
     {
-        ASSERT("semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -589,7 +589,7 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
     status = pthread_mutex_lock(&m_mutexSusp);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
     }
 
     // If the target has already acknowledged the suspend we shouldn't wait.
@@ -600,14 +600,14 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
         status = pthread_cond_wait(&m_condSusp, &m_mutexSusp);
         if (status != 0)
         {
-            ASSERT("pthread_cond_wait returned %d (%s)\n", status, strerror(status));
+            fprintf(stderr, "pthread_cond_wait returned %d (%s)\n", status, strerror(status));
         }
     }
 
     status = pthread_mutex_unlock(&m_mutexSusp);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -625,12 +625,12 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
 #if USE_POSIX_SEMAPHORES
     if (sem_post(&m_semResume) == -1)
     {
-        ASSERT("sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_SYSV_SEMAPHORES
     if (semop(m_nSemrespid, &m_sbSempost, 1) == -1)
     {
-        ASSERT("semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -649,7 +649,7 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
     status = pthread_mutex_lock(&m_mutexResume);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
     }
 
     m_fResumed = TRUE;
@@ -657,13 +657,13 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
     status = pthread_cond_signal(&m_condResume);
     if (status != 0)
     {
-        ASSERT("pthread_cond_signal returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_cond_signal returned %d (%s)\n", status, strerror(status));
     }
 
     status = pthread_mutex_unlock(&m_mutexResume);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -681,12 +681,12 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
 #if USE_POSIX_SEMAPHORES
     while (sem_wait(&m_semResume) == -1)
     {
-        ASSERT("sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_SYSV_SEMAPHORES
     while (semop(m_nSemrespid, &m_sbSemwait, 1) == -1)
     {
-        ASSERT("semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -699,7 +699,7 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
     status = pthread_mutex_lock(&m_mutexResume);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
     }
 
     // If the target has already acknowledged the resume we shouldn't wait.
@@ -710,14 +710,14 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
         status = pthread_cond_wait(&m_condResume, &m_mutexResume);
         if (status != 0)
         {
-            ASSERT("pthread_cond_wait returned %d (%s)\n", status, strerror(status));
+            fprintf(stderr, "pthread_cond_wait returned %d (%s)\n", status, strerror(status));
         }
     }
 
     status = pthread_mutex_unlock(&m_mutexResume);
     if (status != 0)
     {
-        ASSERT("pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -737,7 +737,7 @@ CThreadSuspensionInfo::InitializeSuspensionLock()
     int iError = pthread_mutex_init(&m_ptmSuspmutex, NULL);
     if (0 != iError )
     {
-        ASSERT("pthread_mutex_init(&suspmutex) returned %d\n", iError);
+        fprintf(stderr, "pthread_mutex_init(&suspmutex) returned %d\n", iError);
         return;
     }
     m_fSuspmutexInitialized = TRUE;
@@ -765,7 +765,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     if (0 != iError )
     {
-        ASSERT("sem_init(&suspsem) returned %d\n", iError);
+        fprintf(stderr, "sem_init(&suspsem) returned %d\n", iError);
         goto InitializePreCreateExit;
     }
 
@@ -774,7 +774,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     if (0 != iError )
     {
-        ASSERT("sem_init(&suspsem) returned %d\n", iError);
+        fprintf(stderr, "sem_init(&suspsem) returned %d\n", iError);
         sem_destroy(&m_semSusp);
         goto InitializePreCreateExit;
     }
@@ -787,20 +787,20 @@ CThreadSuspensionInfo::InitializePreCreate()
     m_nSemsuspid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0666);
     if (m_nSemsuspid == -1)
     {
-        ASSERT("semget for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semget for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
 
     m_nSemrespid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0666);
     if (m_nSemrespid == -1)
     {
-        ASSERT("semget for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semget for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
 
     if (m_nSemsuspid == m_nSemrespid)
     {
-        ASSERT("Suspension and Resumption Semaphores have the same id\n");
+        fprintf(stderr, "Suspension and Resumption Semaphores have the same id\n");
         goto InitializePreCreateExit;
     }
 
@@ -808,7 +808,7 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = semctl(m_nSemsuspid, 0, SETVAL, semunData);
     if (iError == -1)
     {
-        ASSERT("semctl for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semctl for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
 
@@ -816,7 +816,7 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = semctl(m_nSemrespid, 0, SETVAL, semunData);
     if (iError == -1)
     {
-        ASSERT("semctl for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        fprintf(stderr, "semctl for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
 
@@ -833,28 +833,28 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = pthread_cond_init(&m_condSusp, NULL);
     if (iError != 0)
     {
-        ASSERT("pthread_cond_init for suspension returned %d (%s)\n", iError, strerror(iError));
+        fprintf(stderr, "pthread_cond_init for suspension returned %d (%s)\n", iError, strerror(iError));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_mutex_init(&m_mutexSusp, NULL);
     if (iError != 0)
     {
-        ASSERT("pthread_mutex_init for suspension returned %d (%s)\n", iError, strerror(iError));
+        fprintf(stderr, "pthread_mutex_init for suspension returned %d (%s)\n", iError, strerror(iError));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_cond_init(&m_condResume, NULL);
     if (iError != 0)
     {
-        ASSERT("pthread_cond_init for resume returned %d (%s)\n", iError, strerror(iError));
+        fprintf(stderr, "pthread_cond_init for resume returned %d (%s)\n", iError, strerror(iError));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_mutex_init(&m_mutexResume, NULL);
     if (iError != 0)
     {
-        ASSERT("pthread_mutex_init for resume returned %d (%s)\n", iError, strerror(iError));
+        fprintf(stderr, "pthread_mutex_init for resume returned %d (%s)\n", iError, strerror(iError));
         goto InitializePreCreateExit;
     }
 
@@ -878,7 +878,7 @@ InitializePreCreateExit:
             }
             default:
             {
-                ASSERT("A pthrSuspender init call returned %d (%s)\n", iError, strerror(iError));
+                fprintf(stderr, "A pthrSuspender init call returned %d (%s)\n", iError, strerror(iError));
                 palError = ERROR_INTERNAL_ERROR;
             }
         }

--- a/chakracore-cxx/pal/src/thread/threadsusp.cpp
+++ b/chakracore-cxx/pal/src/thread/threadsusp.cpp
@@ -35,6 +35,7 @@ Revision History:
 #include <limits.h>
 #include <debugmacrosext.h>
 #include "chakra/Logger.h"
+#include <format>
 
 #if defined(_AIX)
 // AIX requires explicit definition of the union semun (see semctl man page)
@@ -290,7 +291,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
                 // Some other error occurred; need to release suspension mutexes before leaving ResumeThread.
                 palError = ERROR_INTERNAL_ERROR;
                 ReleaseSuspensionLocks(pthrResumer, pthrTarget);
-                fprintf(stderr, "Write() failed; error is %d (%s)\n", errno, strerror(errno));
+                chakra::Logger::error(std::format("Write() failed; error is {} ({})\n", errno, strerror(errno)));
                 goto InternalResumeThreadFromDataExit;
             }
         }
@@ -516,12 +517,12 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
 #if USE_POSIX_SEMAPHORES
     if (sem_post(&m_semSusp) == -1)
     {
-        fprintf(stderr, "sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("sem_post returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_SYSV_SEMAPHORES
     if (semop(m_nSemsuspid, &m_sbSempost, 1) == -1)
     {
-        fprintf(stderr, "semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semop - post returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -540,7 +541,7 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
     status = pthread_mutex_lock(&m_mutexSusp);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_lock returned {} ({})\n", status, strerror(status)));
     }
 
     m_fSuspended = TRUE;
@@ -548,13 +549,13 @@ CThreadSuspensionInfo::PostOnSuspendSemaphore()
     status = pthread_cond_signal(&m_condSusp);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_cond_signal returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_cond_signal returned {} ({})\n", status, strerror(status)));
     }
 
     status = pthread_mutex_unlock(&m_mutexSusp);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_unlock returned {} ({})\n", status, strerror(status)));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -572,12 +573,12 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
 #if USE_POSIX_SEMAPHORES
     while (sem_wait(&m_semSusp) == -1)
     {
-        fprintf(stderr, "sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("sem_wait returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_SYSV_SEMAPHORES
     while (semop(m_nSemsuspid, &m_sbSemwait, 1) == -1)
     {
-        fprintf(stderr, "semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semop wait returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -590,7 +591,7 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
     status = pthread_mutex_lock(&m_mutexSusp);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_lock returned {} ({})\n", status, strerror(status)));
     }
 
     // If the target has already acknowledged the suspend we shouldn't wait.
@@ -601,14 +602,14 @@ CThreadSuspensionInfo::WaitOnSuspendSemaphore()
         status = pthread_cond_wait(&m_condSusp, &m_mutexSusp);
         if (status != 0)
         {
-            fprintf(stderr, "pthread_cond_wait returned %d (%s)\n", status, strerror(status));
+            chakra::Logger::error(std::format("pthread_cond_wait returned {} ({})\n", status, strerror(status)));
         }
     }
 
     status = pthread_mutex_unlock(&m_mutexSusp);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_unlock returned {} ({})\n", status, strerror(status)));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -626,12 +627,12 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
 #if USE_POSIX_SEMAPHORES
     if (sem_post(&m_semResume) == -1)
     {
-        fprintf(stderr, "sem_post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("sem_post returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_SYSV_SEMAPHORES
     if (semop(m_nSemrespid, &m_sbSempost, 1) == -1)
     {
-        fprintf(stderr, "semop - post returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semop - post returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -650,7 +651,7 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
     status = pthread_mutex_lock(&m_mutexResume);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_lock returned {} ({})\n", status, strerror(status)));
     }
 
     m_fResumed = TRUE;
@@ -658,13 +659,13 @@ CThreadSuspensionInfo::PostOnResumeSemaphore()
     status = pthread_cond_signal(&m_condResume);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_cond_signal returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_cond_signal returned {} ({})\n", status, strerror(status)));
     }
 
     status = pthread_mutex_unlock(&m_mutexResume);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_unlock returned {} ({})\n", status, strerror(status)));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -682,12 +683,12 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
 #if USE_POSIX_SEMAPHORES
     while (sem_wait(&m_semResume) == -1)
     {
-        fprintf(stderr, "sem_wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("sem_wait returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_SYSV_SEMAPHORES
     while (semop(m_nSemrespid, &m_sbSemwait, 1) == -1)
     {
-        fprintf(stderr, "semop wait returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semop wait returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
     }
 #elif USE_PTHREAD_CONDVARS
     int status;
@@ -700,7 +701,7 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
     status = pthread_mutex_lock(&m_mutexResume);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_lock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_lock returned {} ({})\n", status, strerror(status)));
     }
 
     // If the target has already acknowledged the resume we shouldn't wait.
@@ -711,14 +712,14 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
         status = pthread_cond_wait(&m_condResume, &m_mutexResume);
         if (status != 0)
         {
-            fprintf(stderr, "pthread_cond_wait returned %d (%s)\n", status, strerror(status));
+            chakra::Logger::error(std::format("pthread_cond_wait returned {} ({})\n", status, strerror(status)));
         }
     }
 
     status = pthread_mutex_unlock(&m_mutexResume);
     if (status != 0)
     {
-        fprintf(stderr, "pthread_mutex_unlock returned %d (%s)\n", status, strerror(status));
+        chakra::Logger::error(std::format("pthread_mutex_unlock returned {} ({})\n", status, strerror(status)));
     }
 #endif // USE_POSIX_SEMAPHORES
 }
@@ -738,7 +739,7 @@ CThreadSuspensionInfo::InitializeSuspensionLock()
     int iError = pthread_mutex_init(&m_ptmSuspmutex, NULL);
     if (0 != iError )
     {
-        fprintf(stderr, "pthread_mutex_init(&suspmutex) returned %d\n", iError);
+        chakra::Logger::error(std::format("pthread_mutex_init(&suspmutex) returned {}\n", iError));
         return;
     }
     m_fSuspmutexInitialized = TRUE;
@@ -766,7 +767,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     if (0 != iError )
     {
-        fprintf(stderr, "sem_init(&suspsem) returned %d\n", iError);
+        chakra::Logger::error(std::format("sem_init(&suspsem) returned {}\n", iError));
         goto InitializePreCreateExit;
     }
 
@@ -775,7 +776,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     if (0 != iError )
     {
-        fprintf(stderr, "sem_init(&suspsem) returned %d\n", iError);
+        chakra::Logger::error(std::format("sem_init(&suspsem) returned {}\n", iError));
         sem_destroy(&m_semSusp);
         goto InitializePreCreateExit;
     }
@@ -788,14 +789,14 @@ CThreadSuspensionInfo::InitializePreCreate()
     m_nSemsuspid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0666);
     if (m_nSemsuspid == -1)
     {
-        fprintf(stderr, "semget for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semget for suspension sem id returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
         goto InitializePreCreateExit;
     }
 
     m_nSemrespid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0666);
     if (m_nSemrespid == -1)
     {
-        fprintf(stderr, "semget for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semget for resumption sem id returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
         goto InitializePreCreateExit;
     }
 
@@ -809,7 +810,7 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = semctl(m_nSemsuspid, 0, SETVAL, semunData);
     if (iError == -1)
     {
-        fprintf(stderr, "semctl for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semctl for suspension sem id returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
         goto InitializePreCreateExit;
     }
 
@@ -817,7 +818,7 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = semctl(m_nSemrespid, 0, SETVAL, semunData);
     if (iError == -1)
     {
-        fprintf(stderr, "semctl for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
+        chakra::Logger::error(std::format("semctl for resumption sem id returned -1 and set errno to {} ({})\n", errno, strerror(errno)));
         goto InitializePreCreateExit;
     }
 
@@ -834,28 +835,28 @@ CThreadSuspensionInfo::InitializePreCreate()
     iError = pthread_cond_init(&m_condSusp, NULL);
     if (iError != 0)
     {
-        fprintf(stderr, "pthread_cond_init for suspension returned %d (%s)\n", iError, strerror(iError));
+        chakra::Logger::error(std::format("pthread_cond_init for suspension returned {} ({})\n", iError, strerror(iError)));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_mutex_init(&m_mutexSusp, NULL);
     if (iError != 0)
     {
-        fprintf(stderr, "pthread_mutex_init for suspension returned %d (%s)\n", iError, strerror(iError));
+        chakra::Logger::error(std::format("pthread_mutex_init for suspension returned {} ({})\n", iError, strerror(iError)));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_cond_init(&m_condResume, NULL);
     if (iError != 0)
     {
-        fprintf(stderr, "pthread_cond_init for resume returned %d (%s)\n", iError, strerror(iError));
+        chakra::Logger::error(std::format("pthread_cond_init for resume returned {} ({})\n", iError, strerror(iError)));
         goto InitializePreCreateExit;
     }
 
     iError = pthread_mutex_init(&m_mutexResume, NULL);
     if (iError != 0)
     {
-        fprintf(stderr, "pthread_mutex_init for resume returned %d (%s)\n", iError, strerror(iError));
+        chakra::Logger::error(std::format("pthread_mutex_init for resume returned {} ({})\n", iError, strerror(iError)));
         goto InitializePreCreateExit;
     }
 
@@ -879,7 +880,7 @@ InitializePreCreateExit:
             }
             default:
             {
-                fprintf(stderr, "A pthrSuspender init call returned %d (%s)\n", iError, strerror(iError));
+                chakra::Logger::error(std::format("A pthrSuspender init call returned {} ({})\n", iError, strerror(iError)));
                 palError = ERROR_INTERNAL_ERROR;
             }
         }

--- a/chakracore-sys/Cargo.toml
+++ b/chakracore-sys/Cargo.toml
@@ -7,6 +7,7 @@ links = "chakracore-sys"
 [dependencies]
 cxx = "1.0.194"
 serde = { version = "1.0.229", features = ["derive"] }
+tracing = "0.1.44"
 
 [build-dependencies]
 cmake = "0.1.57"

--- a/chakracore-sys/build.rs
+++ b/chakracore-sys/build.rs
@@ -76,6 +76,7 @@ fn main() {
 
         println!("cargo::rustc-link-lib=chhelper");
         println!("cargo::rustc-link-lib=ChakraCoreStatic");
+        println!("cargo::rustc-link-lib=Chakra.Ffi");
 
         if cfg!(target_os = "macos") {
             println!("cargo::rustc-link-search=native=/opt/homebrew/opt/icu4c/lib");

--- a/chakracore-sys/build.rs
+++ b/chakracore-sys/build.rs
@@ -1,7 +1,12 @@
 use std::path::PathBuf;
 
 fn main() {
-    let bridges = ["src/chhelper.rs", "src/config.rs", "src/str_helper.rs"];
+    let bridges = [
+        "src/chhelper.rs",
+        "src/config.rs",
+        "src/logger.rs",
+        "src/str_helper.rs",
+    ];
     let mut cxx_bridge = cxx_build::bridges(bridges);
     cxx_bridge
         .include("../chakracore-cxx/bin/ch")
@@ -83,6 +88,7 @@ fn main() {
     }
 
     println!("cargo::rerun-if-changed=../chakracore-cxx/bin/");
+    println!("cargo::rerun-if-changed=../chakracore-cxx/ffi/");
     println!("cargo::rerun-if-changed=../chakracore-cxx/lib/");
     println!("cargo::rerun-if-changed=../chakracore-cxx/pal/");
     println!("cargo::rerun-if-changed=../chakracore-cxx/CMakeLists.txt");

--- a/chakracore-sys/build.rs
+++ b/chakracore-sys/build.rs
@@ -5,6 +5,7 @@ fn main() {
     let mut cxx_bridge = cxx_build::bridges(bridges);
     cxx_bridge
         .include("../chakracore-cxx/bin/ch")
+        .include("../chakracore-cxx/lib/Common")
         .compile("binding");
 
     let out_dir = std::env::var("OUT_DIR").unwrap();

--- a/chakracore-sys/src/chhelper.rs
+++ b/chakracore-sys/src/chhelper.rs
@@ -8,11 +8,16 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("chhelper.h");
         include!("chakracore-sys/src/config.rs.h");
+        include!("Util/Abstractions.h");
 
         #[namespace = "chakra_rs::config"]
         type CoreConfig = crate::config::CoreConfig;
 
         fn main_internal(config: CoreConfig) -> i32;
+
+        type Abstractions;
+        #[Self = "Abstractions"]
+        fn IsDebuggerPresent() -> bool;
     }
 }
 

--- a/chakracore-sys/src/lib.rs
+++ b/chakracore-sys/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod chhelper;
 pub mod config;
+mod logger;
 pub mod str_helper;

--- a/chakracore-sys/src/logger.rs
+++ b/chakracore-sys/src/logger.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge(namespace = "chakra_rs::log")]
+mod ffi {
+    extern "Rust" {
+        fn error(function_name: &str, file_name: &str, line: u32, message: &str);
+    }
+}
+
+fn error(function_name: &str, file_name: &str, line: u32, message: &str) {
+    tracing::error!(function_name, file_name, line, message);
+}

--- a/chakracore/Cargo.toml
+++ b/chakracore/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2024"
 chakracore-sys = { path = "../chakracore-sys" }
 serde_json = "1.0.151"
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 rstest = "0.26.1"
+serde = { version = "1.0.229", features = ["derive"] }
 
 [features]
 compile-cpp = ["chakracore-sys/compile-cpp"]

--- a/chakracore/Cargo.toml
+++ b/chakracore/Cargo.toml
@@ -10,6 +10,8 @@ serde_json = "1.0.151"
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 rstest = "0.26.1"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [features]
 compile-cpp = ["chakracore-sys/compile-cpp"]

--- a/chakracore/Cargo.toml
+++ b/chakracore/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2024"
 [dependencies]
 chakracore-sys = { path = "../chakracore-sys" }
 serde_json = "1.0.151"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 rstest = "0.26.1"
-tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [features]
 compile-cpp = ["chakracore-sys/compile-cpp"]

--- a/chakracore/src/main.rs
+++ b/chakracore/src/main.rs
@@ -5,7 +5,12 @@ use tracing_subscriber::filter::LevelFilter;
 
 fn main() -> ExitCode {
     tracing_subscriber::fmt()
+        .json()
         .with_max_level(LevelFilter::TRACE)
+        .with_writer(std::io::stderr)
+        .with_thread_names(true)
+        .with_target(false)
+        .without_time()
         .init();
     let wait_for_debugger = std::env::var("WAIT_FOR_DEBUGGER")
         .unwrap_or_default()
@@ -27,6 +32,8 @@ fn main() -> ExitCode {
         } else {
             tracing::info!("debugger attached");
         }
+    } else {
+        tracing::debug!("not waiting for debugger");
     }
 
     let args: Vec<_> = std::env::args().collect();

--- a/chakracore/src/main.rs
+++ b/chakracore/src/main.rs
@@ -1,7 +1,34 @@
+use chakracore_sys::chhelper::ffi::Abstractions;
 use chakracore_sys::config::CoreConfig;
 use std::process::ExitCode;
+use tracing_subscriber::filter::LevelFilter;
 
 fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::TRACE)
+        .init();
+    let wait_for_debugger = std::env::var("WAIT_FOR_DEBUGGER")
+        .unwrap_or_default()
+        .parse::<bool>()
+        .unwrap_or_default();
+
+    if wait_for_debugger {
+        let mut counter = 0;
+        while !Abstractions::IsDebuggerPresent() && counter < 30 {
+            let skip_assert = true;
+            tracing::debug!(counter, skip_assert, "waiting for debugger");
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            counter += 1;
+        }
+
+        if counter >= 30 {
+            tracing::warn!("debugger did not attach in time");
+            return ExitCode::FAILURE;
+        } else {
+            tracing::info!("debugger attached");
+        }
+    }
+
     let args: Vec<_> = std::env::args().collect();
     let Some(chakra_args) = ChakraArgs::new(args) else {
         chakracore_sys::chhelper::print_usage();

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -5,6 +5,8 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
+use tracing::instrument;
+use tracing_subscriber::EnvFilter;
 
 pub const CH_PATH: &'static str = env!("CARGO_BIN_EXE_chakracore");
 pub const SLOW_TEST_TIMEOUT: Duration = Duration::from_secs(180);
@@ -83,6 +85,7 @@ pub enum Variant {
     DisableJit,
 }
 
+#[derive(Debug)]
 struct VariantConfig<'a> {
     compile_flags: Vec<&'a str>,
     excluded_tags: HashSet<&'static str>,
@@ -93,6 +96,16 @@ pub fn run_test_variant<const N: usize>(
     variant: Variant,
     common_tags: [&'static str; N],
 ) {
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")),
+            )
+            .with_test_writer()
+            .finish(),
+    );
+    tracing::info!("starting test");
+
     test.tags.extend(common_tags.iter());
     test.validate();
 
@@ -155,10 +168,16 @@ pub fn run_test_variant<const N: usize>(
     );
 
     if cfg!(disable_jit) && variant != Variant::DisableJit {
-        println!("Skipping {variant:?} as it's not supported with cfg!(disable_jit)");
+        tracing::info!(
+            ?variant,
+            "Skipping variant as it's not supported with `cfg!(disable_jit)`"
+        );
         return;
     } else if !cfg!(disable_jit) && variant == Variant::DisableJit {
-        println!("Skipping {variant:?} as it's not supported without cfg!(disable_jit)");
+        tracing::info!(
+            ?variant,
+            "Skipping variant as it requires `cfg!(disable_jit)`"
+        );
         return;
     }
 
@@ -166,9 +185,6 @@ pub fn run_test_variant<const N: usize>(
 
     let test_dir = manifest_dir.join(test.directory);
     let source = test_dir.join(test.source_path);
-    println!("source_path: {:?}", source);
-
-    dbg!(&test);
 
     assert!(source.exists());
     let filename = source.to_str().unwrap().to_owned();
@@ -182,6 +198,8 @@ pub fn run_test_variant<const N: usize>(
     args.extend(variant_config.compile_flags.into_iter().map(String::from));
 
     let core_config = CoreConfig { filename, args };
+    tracing::info!(?core_config);
+
     let serialized_config = serde_json::to_string(&core_config).unwrap();
     let mut ch = Command::new(CH_PATH);
     ch.current_dir(test_dir).arg(serialized_config);
@@ -190,7 +208,7 @@ pub fn run_test_variant<const N: usize>(
         ch.env("TZ", "America/Los_Angeles");
     }
 
-    println!("Running command: {ch:#?}");
+    tracing::info!(?ch, "Running command");
     let output = ch.output().unwrap();
 
     let mut out = String::from_utf8_lossy(&output.stdout).to_string();
@@ -233,6 +251,7 @@ pub fn run_test_variant<const N: usize>(
     }
 
     assert!(output.status.success());
+    assert!(false);
 }
 
 fn trim_carriage_return(s: &str) -> &str {

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -4,12 +4,11 @@ use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::io::{BufRead, BufReader, Read};
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::str::FromStr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::Duration;
-use tracing::Level;
+use tracing::dispatcher::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 
 pub const CH_PATH: &'static str = env!("CARGO_BIN_EXE_chakracore");
@@ -95,12 +94,8 @@ struct VariantConfig<'a> {
     excluded_tags: HashSet<&'static str>,
 }
 
-pub fn run_test_variant<const N: usize>(
-    mut test: Test,
-    variant: Variant,
-    common_tags: [&'static str; N],
-) {
-    let _subscriber_guard = tracing::subscriber::set_default(
+pub fn init_tracing() -> DefaultGuard {
+    let guard = tracing::subscriber::set_default(
         tracing_subscriber::fmt()
             .with_env_filter(
                 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")),
@@ -109,6 +104,15 @@ pub fn run_test_variant<const N: usize>(
             .finish(),
     );
     tracing::info!("starting test");
+    guard
+}
+
+pub fn run_test_variant<const N: usize>(
+    mut test: Test,
+    variant: Variant,
+    common_tags: [&'static str; N],
+) {
+    let _subscriber_guard = init_tracing();
 
     test.tags.extend(common_tags.iter());
     test.validate();
@@ -202,47 +206,7 @@ pub fn run_test_variant<const N: usize>(
     args.extend(variant_config.compile_flags.into_iter().map(String::from));
 
     let core_config = CoreConfig { filename, args };
-    tracing::info!(?core_config);
-
-    let serialized_config = serde_json::to_string(&core_config).unwrap();
-    let mut ch = Command::new(CH_PATH);
-    ch.current_dir(test_dir)
-        .arg(serialized_config)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env("TZ", "America/Los_Angeles");
-
-    let (status, actual) = {
-        let _span = tracing::info_span!("run_test_variant").entered();
-        tracing::info!(?ch, "Running command");
-
-        let mut child = ch.spawn().unwrap();
-        let stdout = child.stdout.take().unwrap();
-        let stderr = child.stderr.take().unwrap();
-
-        let dispatcher = tracing::dispatcher::get_default(|dispatch| dispatch.clone());
-        let dispatcher2 = dispatcher.clone();
-
-        let stdout_span = tracing::info_span!("stdout_reader");
-        let stdout_reader = thread::spawn(move || {
-            let _span = stdout_span.entered();
-            tracing::dispatcher::with_default(&dispatcher, || read_stdout(stdout))
-        });
-
-        let stderr_span = tracing::info_span!("stderr_reader");
-        let stderr_reader = thread::spawn(move || {
-            let _span = stderr_span.entered();
-            tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
-        });
-
-        let mut actual = stdout_reader.join().unwrap();
-        let err_actual = stderr_reader.join().unwrap();
-        actual.extend(err_actual);
-
-        let status = child.wait().unwrap();
-        tracing::info!(?status, "Child process exited");
-        (status, actual)
-    };
+    let (status, actual) = run_test(core_config, Some(test_dir.as_path()));
 
     match test.baseline_path {
         Some(baseline_path) => {
@@ -277,11 +241,57 @@ pub fn run_test_variant<const N: usize>(
     assert!(status.success());
 }
 
+#[tracing::instrument(skip_all)]
+pub fn run_test(core_config: CoreConfig, test_dir: Option<&Path>) -> (ExitStatus, Vec<String>) {
+    tracing::info!(?core_config);
+
+    let serialized_config = serde_json::to_string(&core_config).unwrap();
+    let mut ch = Command::new(CH_PATH);
+
+    if let Some(test_dir) = test_dir {
+        ch.current_dir(test_dir);
+    }
+
+    ch.arg(serialized_config)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("TZ", "America/Los_Angeles");
+
+    tracing::info!(?ch, "Running command");
+
+    let mut child = ch.spawn().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+
+    let dispatcher = tracing::dispatcher::get_default(|dispatch| dispatch.clone());
+    let dispatcher2 = dispatcher.clone();
+
+    let stdout_span = tracing::info_span!("stdout_reader");
+    let stdout_reader = thread::spawn(move || {
+        let _span = stdout_span.entered();
+        tracing::dispatcher::with_default(&dispatcher, || read_stdout(stdout))
+    });
+
+    let stderr_span = tracing::info_span!("stderr_reader");
+    let stderr_reader = thread::spawn(move || {
+        let _span = stderr_span.entered();
+        tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
+    });
+
+    let mut actual = stdout_reader.join().unwrap();
+    let err_actual = stderr_reader.join().unwrap();
+    actual.extend(err_actual);
+
+    let status = child.wait().unwrap();
+    tracing::info!(?status, "Child process exited");
+    (status, actual)
+}
+
 fn read_stdout<R: Read>(stream: R) -> Vec<String> {
     let mut actual = Vec::new();
     let reader = BufReader::new(stream);
     for message in reader.lines().map(|line| line.unwrap()) {
-        tracing::info!(target: "chakracore", message);
+        tracing::info!(target: "chakracore stdout", message);
         actual.push(message);
     }
     actual
@@ -294,19 +304,19 @@ fn read_stderr<R: Read>(stream: R) -> Vec<String> {
         if let Ok(event) = serde_json::from_str::<ChildEvent>(&message) {
             match event.level.as_str() {
                 "TRACE" => {
-                    tracing::trace!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                    tracing::trace!(target: "chakracore stderr", message = event.fields.message, thread.name = event.thread_name)
                 }
                 "DEBUG" => {
-                    tracing::debug!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                    tracing::debug!(target: "chakracore stderr", message = event.fields.message, thread.name = event.thread_name)
                 }
                 "INFO" => {
-                    tracing::info!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                    tracing::info!(target: "chakracore stderr", message = event.fields.message, thread.name = event.thread_name)
                 }
                 "WARN" => {
-                    tracing::warn!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                    tracing::warn!(target: "chakracore stderr", message = event.fields.message, thread.name = event.thread_name)
                 }
                 "ERROR" => {
-                    tracing::error!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                    tracing::error!(target: "chakracore stderr", message = event.fields.message, thread.name = event.thread_name)
                 }
                 _ => panic!("invalid level: {}", event.level),
             }

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -1,6 +1,7 @@
 use chakracore_sys::config::CoreConfig;
 use pretty_assertions::{assert_eq, assert_ne};
 use serde::Deserialize;
+use std::assert_matches;
 use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::io::{BufRead, BufReader, Read};
@@ -278,9 +279,9 @@ pub fn run_test(core_config: CoreConfig, test_dir: Option<&Path>) -> (ExitStatus
         tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
     });
 
-    let mut actual = stdout_reader.join().unwrap();
+    let actual = stdout_reader.join().unwrap();
     let err_actual = stderr_reader.join().unwrap();
-    actual.extend(err_actual);
+    assert_matches!(err_actual, None);
 
     let status = child.wait().unwrap();
     tracing::info!(?status, "Child process exited");
@@ -297,7 +298,7 @@ fn read_stdout<R: Read>(stream: R) -> Vec<String> {
     actual
 }
 
-fn read_stderr<R: Read>(stream: R) -> Vec<String> {
+fn read_stderr<R: Read>(stream: R) -> Option<Vec<String>> {
     let mut actual = Vec::new();
     let reader = BufReader::new(stream);
     for message in reader.lines().map(|line| line.unwrap()) {
@@ -321,10 +322,15 @@ fn read_stderr<R: Read>(stream: R) -> Vec<String> {
                 _ => panic!("invalid level: {}", event.level),
             }
         } else {
+            tracing::error!(message, "Failed to parse message:");
             actual.push(message);
         }
     }
-    actual
+    if actual.is_empty() {
+        None
+    } else {
+        Some(actual)
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -2,10 +2,11 @@ use chakracore_sys::config::CoreConfig;
 use pretty_assertions::{assert_eq, assert_ne};
 use std::collections::HashSet;
 use std::fs::read_to_string;
+use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::thread;
 use std::time::Duration;
-use tracing::instrument;
 use tracing_subscriber::EnvFilter;
 
 pub const CH_PATH: &'static str = env!("CARGO_BIN_EXE_chakracore");
@@ -96,7 +97,7 @@ pub fn run_test_variant<const N: usize>(
     variant: Variant,
     common_tags: [&'static str; N],
 ) {
-    let _subscriber = tracing::subscriber::set_default(
+    let _subscriber_guard = tracing::subscriber::set_default(
         tracing_subscriber::fmt()
             .with_env_filter(
                 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")),
@@ -202,23 +203,34 @@ pub fn run_test_variant<const N: usize>(
 
     let serialized_config = serde_json::to_string(&core_config).unwrap();
     let mut ch = Command::new(CH_PATH);
-    ch.current_dir(test_dir).arg(serialized_config);
-
-    if cfg!(unix) {
-        ch.env("TZ", "America/Los_Angeles");
-    }
+    ch.current_dir(test_dir)
+        .arg(serialized_config)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("TZ", "America/Los_Angeles");
 
     tracing::info!(?ch, "Running command");
-    let output = ch.output().unwrap();
 
-    let mut out = String::from_utf8_lossy(&output.stdout).to_string();
-    let err = String::from_utf8_lossy(&output.stderr);
-    out.push_str(&err);
+    let mut child = ch.spawn().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
 
-    let actual = out
-        .lines()
-        .map(|s| trim_carriage_return(s))
-        .collect::<Vec<_>>();
+    let dispatcher = tracing::dispatcher::get_default(|dispatch| dispatch.clone());
+    let dispatcher2 = dispatcher.clone();
+
+    let stdout_reader = thread::spawn(move || {
+        tracing::dispatcher::with_default(&dispatcher, || read_stdout(stdout))
+    });
+    let stderr_reader = thread::spawn(move || {
+        tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
+    });
+
+    let mut actual = stdout_reader.join().unwrap();
+    let err_actual = stderr_reader.join().unwrap();
+    actual.extend(err_actual);
+
+    let status = child.wait().unwrap();
+    tracing::info!("Child process exited");
 
     match test.baseline_path {
         Some(baseline_path) => {
@@ -250,8 +262,29 @@ pub fn run_test_variant<const N: usize>(
         }
     }
 
-    assert!(output.status.success());
-    assert!(false);
+    assert!(status.success());
+}
+
+#[tracing::instrument(skip_all, name = "stdout")]
+fn read_stdout<R: Read>(stream: R) -> Vec<String> {
+    let mut actual = Vec::new();
+    let reader = BufReader::new(stream);
+    for message in reader.lines().map(|line| line.unwrap()) {
+        tracing::info!(target: "chakracore", message);
+        actual.push(message);
+    }
+    actual
+}
+
+#[tracing::instrument(skip_all, name = "stderr")]
+fn read_stderr<R: Read>(stream: R) -> Vec<String> {
+    let mut actual = Vec::new();
+    let reader = BufReader::new(stream);
+    for message in reader.lines().map(|line| line.unwrap()) {
+        tracing::info!(target: "chakracore", message);
+        actual.push(message);
+    }
+    actual
 }
 
 fn trim_carriage_return(s: &str) -> &str {

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -1,12 +1,15 @@
 use chakracore_sys::config::CoreConfig;
 use pretty_assertions::{assert_eq, assert_ne};
+use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
+use tracing::Level;
 use tracing_subscriber::EnvFilter;
 
 pub const CH_PATH: &'static str = env!("CARGO_BIN_EXE_chakracore");
@@ -288,10 +291,45 @@ fn read_stderr<R: Read>(stream: R) -> Vec<String> {
     let mut actual = Vec::new();
     let reader = BufReader::new(stream);
     for message in reader.lines().map(|line| line.unwrap()) {
-        tracing::info!(target: "chakracore", message);
-        actual.push(message);
+        if let Ok(event) = serde_json::from_str::<ChildEvent>(&message) {
+            match event.level.as_str() {
+                "TRACE" => {
+                    tracing::trace!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                }
+                "DEBUG" => {
+                    tracing::debug!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                }
+                "INFO" => {
+                    tracing::info!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                }
+                "WARN" => {
+                    tracing::warn!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                }
+                "ERROR" => {
+                    tracing::error!(target: "chakracore", message = event.fields.message, thread.name = event.thread_name)
+                }
+                _ => panic!("invalid level: {}", event.level),
+            }
+        } else {
+            actual.push(message);
+        }
     }
     actual
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChildEvent {
+    level: String,
+    fields: ChildEventFields,
+    #[serde(rename = "threadName")]
+    thread_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChildEventFields {
+    message: String,
 }
 
 fn trim_carriage_return(s: &str) -> &str {

--- a/chakracore/tests/integration/common.rs
+++ b/chakracore/tests/integration/common.rs
@@ -209,28 +209,37 @@ pub fn run_test_variant<const N: usize>(
         .stderr(Stdio::piped())
         .env("TZ", "America/Los_Angeles");
 
-    tracing::info!(?ch, "Running command");
+    let (status, actual) = {
+        let _span = tracing::info_span!("run_test_variant").entered();
+        tracing::info!(?ch, "Running command");
 
-    let mut child = ch.spawn().unwrap();
-    let stdout = child.stdout.take().unwrap();
-    let stderr = child.stderr.take().unwrap();
+        let mut child = ch.spawn().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
 
-    let dispatcher = tracing::dispatcher::get_default(|dispatch| dispatch.clone());
-    let dispatcher2 = dispatcher.clone();
+        let dispatcher = tracing::dispatcher::get_default(|dispatch| dispatch.clone());
+        let dispatcher2 = dispatcher.clone();
 
-    let stdout_reader = thread::spawn(move || {
-        tracing::dispatcher::with_default(&dispatcher, || read_stdout(stdout))
-    });
-    let stderr_reader = thread::spawn(move || {
-        tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
-    });
+        let stdout_span = tracing::info_span!("stdout_reader");
+        let stdout_reader = thread::spawn(move || {
+            let _span = stdout_span.entered();
+            tracing::dispatcher::with_default(&dispatcher, || read_stdout(stdout))
+        });
 
-    let mut actual = stdout_reader.join().unwrap();
-    let err_actual = stderr_reader.join().unwrap();
-    actual.extend(err_actual);
+        let stderr_span = tracing::info_span!("stderr_reader");
+        let stderr_reader = thread::spawn(move || {
+            let _span = stderr_span.entered();
+            tracing::dispatcher::with_default(&dispatcher2, || read_stderr(stderr))
+        });
 
-    let status = child.wait().unwrap();
-    tracing::info!("Child process exited");
+        let mut actual = stdout_reader.join().unwrap();
+        let err_actual = stderr_reader.join().unwrap();
+        actual.extend(err_actual);
+
+        let status = child.wait().unwrap();
+        tracing::info!(?status, "Child process exited");
+        (status, actual)
+    };
 
     match test.baseline_path {
         Some(baseline_path) => {
@@ -265,7 +274,6 @@ pub fn run_test_variant<const N: usize>(
     assert!(status.success());
 }
 
-#[tracing::instrument(skip_all, name = "stdout")]
 fn read_stdout<R: Read>(stream: R) -> Vec<String> {
     let mut actual = Vec::new();
     let reader = BufReader::new(stream);
@@ -276,7 +284,6 @@ fn read_stdout<R: Read>(stream: R) -> Vec<String> {
     actual
 }
 
-#[tracing::instrument(skip_all, name = "stderr")]
 fn read_stderr<R: Read>(stream: R) -> Vec<String> {
     let mut actual = Vec::new();
     let reader = BufReader::new(stream);

--- a/chakracore/tests/integration/tests/smoke_tests.rs
+++ b/chakracore/tests/integration/tests/smoke_tests.rs
@@ -1,4 +1,4 @@
-use crate::common::CH_PATH;
+use crate::common::{init_tracing, run_test};
 use chakracore_sys::config::CoreConfig;
 
 #[test]
@@ -8,17 +8,11 @@ fn hello() {
         filename: source.to_owned(),
         ..Default::default()
     };
-    let config = serde_json::to_string(&config).unwrap();
 
-    let mut ch_exe = std::process::Command::new(CH_PATH);
-    ch_exe.arg(config);
-    let output = ch_exe.output().unwrap();
+    let _guard = init_tracing();
+    let (exit_status, actual) = run_test(config, None);
 
-    let out = String::from_utf8_lossy(&output.stdout);
-
-    let actual = out.lines().collect::<Vec<_>>();
     let expected = vec!["hello world", "PASS"];
     assert_eq!(actual, expected);
-    assert_eq!(output.stderr, b"");
-    assert!(output.status.success());
+    assert!(exit_status.success());
 }


### PR DESCRIPTION
- use tracing for test-host
- stream stdout and stderr during test execution
- Cli emits logs as json to stderr. Test host parses json and emits those logs again. Can't spawn child process with inherited stderr because then it will always show logs when tests don't fail.
- stderr is now only used for logs, tests no longer depend on it